### PR TITLE
fix SyntaxError for Python2.6 in bdist_wheel

### DIFF
--- a/wheel/bdist_wheel.py
+++ b/wheel/bdist_wheel.py
@@ -403,10 +403,8 @@ class bdist_wheel(Command):
             pkg_info = self._pkginfo_to_metadata(egginfo_path, pkginfo_path)
 
             # ignore common egg metadata that is useless to wheel
-            shutil.copytree(egginfo_path, distinfo_path,
-                            ignore=lambda x, y: {'PKG-INFO', 'requires.txt', 'SOURCES.txt',
-                                                 'not-zip-safe'}
-                            )
+            ignore = ('PKG-INFO', 'requires.txt', 'SOURCES.txt', 'not-zip-safe')
+            shutil.copytree(egginfo_path, distinfo_path, ignore=lambda x, y: set(ignore))
 
             # delete dependency_links if it is only whitespace
             dependency_links_path = os.path.join(distinfo_path, 'dependency_links.txt')


### PR DESCRIPTION
The `ignore` argument of `shutil.copytree` accepts a lambda that returns a set.
Current syntax (`{'PKG-INFO', 'requires.txt', 'SOURCES.txt', 'not-zip-safe'}`) fails under Python 2.6.

Many systems, especially CI pipelines (including pypa's repos, e.g.: https://travis-ci.org/pypa/setuptools/jobs/274882073) are still using Python2.6.x.

Please consider to fix this syntax error under Python 2.6, or remove tests under Python 2.6 in pypa repos' CI pipelines.