### PR TITLE
Log removal of bdist_dir always instead of just during a dry run

### DIFF
--- a/wheel/bdist_wheel.py
+++ b/wheel/bdist_wheel.py
@@ -274,9 +274,8 @@ class bdist_wheel(Command):
             ('bdist_wheel', get_python_version(), wheel_name))
 
         if not self.keep_temp:
-            if self.dry_run:
-                logger.info('removing %s', self.bdist_dir)
-            else:
+            logger.info('removing %s', self.bdist_dir)
+            if not self.dry_run:
                 rmtree(self.bdist_dir)
 
     def write_wheelfile(self, wheelfile_base, generator='bdist_wheel (' + wheel_version + ')'):


### PR DESCRIPTION
When trying to help debugging a build of a package made by someone else I got confused as there was no indicated files available under the bdist directory. This PR just moves the log message to be displayed even when no `--dry-run` is defined to avoid such confusions in the future.