### PR TITLE
Fix handling of requirements' environment markers.

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,25 @@
+from wheel.metadata import generate_requirements
+
+
+def test_generate_requirements():
+    extras_require = {
+        'test': ['ipykernel', 'ipython', 'mock'],
+        'test:python_version == "3.3"': ['pytest<3.3.0'],
+        'test:python_version >= "3.4" or python_version == "2.7"': ['pytest'],
+    }
+    expected_metadata = [
+        ('Provides-Extra',
+         'test'),
+        ('Requires-Dist',
+         "ipykernel; extra == 'test'"),
+        ('Requires-Dist',
+         "ipython; extra == 'test'"),
+        ('Requires-Dist',
+         "mock; extra == 'test'"),
+        ('Requires-Dist',
+         'pytest (<3.3.0); (python_version == "3.3") and extra == \'test\''),
+        ('Requires-Dist',
+         'pytest; (python_version >= "3.4" or python_version == "2.7") and extra == \'test\''),
+    ]
+    generated_metadata = sorted(set(generate_requirements(extras_require)))
+    assert generated_metadata == expected_metadata

--- a/wheel/metadata.py
+++ b/wheel/metadata.py
@@ -255,7 +255,7 @@ def generate_requirements(extras_require):
         if extra:
             yield ('Provides-Extra', extra)
             if condition:
-                condition += " and "
+                condition = "(" + condition + ") and "
             condition += "extra == '%s'" % extra
         if condition:
             condition = '; ' + condition


### PR DESCRIPTION
Parenthesize markers before adding the `and extra == "..."` clause so it does not break the logic of the preceding expression when `or` operands are used. Fix #212.