### PR TITLE
Prefer dict literals over calls to dict()

### DIFF
--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -5,7 +5,7 @@ WHEELPAT = "%(name)s-%(ver)s-%(pyver)s-%(abi)s-%(arch)s.whl"
 
 
 def make_wheel(name, ver, pyver, abi, arch):
-    name = WHEELPAT % dict(name=name, ver=ver, pyver=pyver, abi=abi, arch=arch)
+    name = WHEELPAT % {'name': name, 'ver': ver, 'pyver': pyver, 'abi': abi, 'arch': arch}
     return WheelFile(name)
 
 

--- a/wheel/util.py
+++ b/wheel/util.py
@@ -122,7 +122,7 @@ if sys.platform == 'win32':
     import ctypes.wintypes
     # CSIDL_APPDATA for reference - not used here for compatibility with
     # dirspec, which uses LOCAL_APPDATA and COMMON_APPDATA in that order
-    csidl = dict(CSIDL_APPDATA=26, CSIDL_LOCAL_APPDATA=28, CSIDL_COMMON_APPDATA=35)
+    csidl = {'CSIDL_APPDATA': 26, 'CSIDL_LOCAL_APPDATA': 28, 'CSIDL_COMMON_APPDATA': 35}
 
     def get_path(name):
         SHGFP_TYPE_CURRENT = 0

--- a/wheel/wininst2wheel.py
+++ b/wheel/wininst2wheel.py
@@ -84,7 +84,7 @@ def parse_info(wininfo_name, egginfo_name):
         w_name = egginfo.group('name')
         w_ver = egginfo.group('ver')
 
-    return dict(name=w_name, ver=w_ver, arch=w_arch, pyver=w_pyver)
+    return {'name': w_name, 'ver': w_ver, 'arch': w_arch, 'pyver': w_pyver}
 
 
 def bdist_wininst2wheel(path, dest_dir=os.path.curdir):


### PR DESCRIPTION
dict literals are idiomatic and Pythonic patterns that utilize modern
syntax. A dict literal is always slightly faster than a call to dict().

$ python3 -m timeit 'dict(a=1, b=2, c=3)'
10000000 loops, best of 3: 0.187 usec per loop
$ python3 -m timeit '{"a": 1, "b": 2, "c": 3}'
10000000 loops, best of 3: 0.0705 usec per loop