### PR TITLE
Use a raw string for EXTRA Regex to avoid invalid escape sequences

### DIFF
--- a/wheel/metadata.py
+++ b/wheel/metadata.py
@@ -32,7 +32,9 @@ UNKNOWN_FIELDS = {"author", "author_email", "platform", "home_page", "license"}
 
 # Wheel itself is probably the only program that uses non-extras markers
 # in METADATA/PKG-INFO. Support its syntax with the extra at the end only.
-EXTRA_RE = re.compile("""^(?P<package>.*?)(;\s*(?P<condition>.*?)(extra == '(?P<extra>.*?)')?)$""")
+EXTRA_RE = re.compile(
+    r"""^(?P<package>.*?)(;\s*(?P<condition>.*?)(extra == '(?P<extra>.*?)')?)$"""
+)
 KEYWORDS_RE = re.compile("[\0-,]+")
 
 MayRequiresKey = namedtuple('MayRequiresKey', ('condition', 'extra'))


### PR DESCRIPTION
- Python 3.6 shows this regex containing "invalid escape sequence"
```
wheel-0.30.0-py2.py3-none-any.whl-installed/wheel/metadata.py:35: DeprecationWarning: invalid escape sequence \s
  EXTRA_RE = re.compile("""^(?P<package>.*?)(;\s*(?P<condition>.*?)(extra == '(?P<extra>.*?)')?)$""")
```
- Raw string will help Python be happy here.