### PR TITLE
enable pip cache in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+cache: pip
 
 jobs:
   include:


### PR DESCRIPTION
using pypi resources should be minimized, and caching the packages on travis helps with that.