### PR TITLE
Metadata 2.1 updates

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ Unreleased
 - Fixed displaying of errors on Python 3
 - Fixed single digit versions in wheel files not being properly recognized
 - Enabled Zip64 support in wheels by default
+- Metadata-Version is now 2.1
+- Don't create a DESCRIPTION.RST anymore.
 
 0.30.0
 ======

--- a/tests/pydist-schema.json
+++ b/tests/pydist-schema.json
@@ -1,7 +1,7 @@
 {
   "id": "http://www.python.org/dev/peps/pep-0426/",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Metadata for Python Software Packages 2.0",
+  "title": "Metadata for Python Software Packages 2.1",
   "type": "object",
   "properties": {
     "metadata_version": {

--- a/tests/test_pkginfo.py
+++ b/tests/test_pkginfo.py
@@ -6,7 +6,7 @@ from wheel.pkginfo import write_pkg_info
 def test_pkginfo_mangle_from(tmpdir):
     """Test that write_pkginfo() will not prepend a ">" to a line starting with "From"."""
     metadata = """\
-Metadata-Version: 2.0
+Metadata-Version: 2.1
 Name: foo
 
 From blahblah

--- a/wheel/bdist_wheel.py
+++ b/wheel/bdist_wheel.py
@@ -426,14 +426,8 @@ class bdist_wheel(Command):
                                  distribution=self.distribution)
 
         if 'description' in pymeta:
-            description_filename = 'DESCRIPTION.rst'
-            description_text = pymeta.pop('description')
-            description_path = os.path.join(distinfo_path,
-                                            description_filename)
-            with open(description_path, "wb") as description_file:
-                description_file.write(description_text.encode('utf-8'))
-            pymeta['extensions']['python.details']['document_names']['description'] = \
-                description_filename
+            # Don't include `description` in JSON metadata
+            pymeta.pop('description')
 
         # XXX heuristically copy any LICENSE/LICENSE.txt?
         license = self.license_file()

--- a/wheel/metadata.py
+++ b/wheel/metadata.py
@@ -14,7 +14,7 @@ from . import __version__ as wheel_version
 from .pkginfo import read_pkg_info
 from .util import OrderedDefaultDict
 
-METADATA_VERSION = "2.0"
+METADATA_VERSION = "2.1"
 
 PLURAL_FIELDS = {"classifier": "classifiers",
                  "provides_dist": "provides",
@@ -265,11 +265,10 @@ def generate_requirements(extras_require):
 
 def pkginfo_to_metadata(egg_info_path, pkginfo_path):
     """
-    Convert .egg-info directory with PKG-INFO to the Metadata 1.3 aka
-    old-draft Metadata 2.0 format.
+    Convert .egg-info directory with PKG-INFO to the Metadata 2.1 format
     """
     pkg_info = read_pkg_info(pkginfo_path)
-    pkg_info.replace_header('Metadata-Version', '2.0')
+    pkg_info.replace_header('Metadata-Version', '2.1')
     requires_path = os.path.join(egg_info_path, 'requires.txt')
     if os.path.exists(requires_path):
         with open(requires_path) as requires_file:


### PR DESCRIPTION
Fixes #231:

* Set `Metadata-Version` to 2.1
* Don't create a `DESCRIPTION.rst`

(ping @agronholm)