### PR TITLE
Log a warning when the [wheel] section is used

### DIFF
--- a/wheel/bdist_wheel.py
+++ b/wheel/bdist_wheel.py
@@ -128,6 +128,7 @@ class bdist_wheel(Command):
         wheel = self.distribution.get_option_dict('wheel')
         if 'universal' in wheel:
             # please don't define this in your global configs
+            logger.warn('The [wheel] section is deprecated. Use [bdist_wheel] instead.')
             val = wheel['universal'][1].strip()
             if val.lower() in ('1', 'true', 'yes'):
                 self.universal = True


### PR DESCRIPTION
Has been considered legacy since b2d2165fa32e2684cf1aeb0605f2ee8a2108c129 (2014-03-17) or version 0.23.0. However, projects continue to use the `[wheel]` section. Adding a warning might help move more projects to the recommended `[bdist_wheel]`.