### PR TITLE
dedupe metadata lines

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -23,3 +23,26 @@ def test_generate_requirements():
     ]
     generated_metadata = sorted(set(generate_requirements(extras_require)))
     assert generated_metadata == expected_metadata
+
+
+def test_generate_requirements_no_duplicate_extras():
+    extras_require = {
+        'signatures': ['keyring', 'keyrings.alt'],
+        'signatures:sys_platform!="win32"': ['pyxdg'],
+        'faster-signatures': ['ed25519ll'],
+        'test': ['pytest >= 3.0.0', 'pytest-cov']
+    }
+    expected_metadata = [
+        ('Provides-Extra', 'faster-signatures'),
+        ('Provides-Extra', 'signatures'),
+        ('Provides-Extra', 'test'),
+        ('Requires-Dist', "ed25519ll; extra == 'faster-signatures'"),
+        ('Requires-Dist', "keyring; extra == 'signatures'"),
+        ('Requires-Dist', "keyrings.alt; extra == 'signatures'"),
+        ('Requires-Dist', "pytest (>=3.0.0); extra == 'test'"),
+        ('Requires-Dist', "pytest-cov; extra == 'test'"),
+        ('Requires-Dist',
+         'pyxdg; (sys_platform!="win32") and extra == \'signatures\''),
+    ]
+    generated_metadata = sorted(generate_requirements(extras_require))
+    assert generated_metadata == expected_metadata


### PR DESCRIPTION
Wheel's handling of `Provides-Extra` package info is a bit of a mess.  For example, wheel's own wheel `wheel-0.31.1-py2.py3-none-any.whl` has this in the `METADATA` file

```
Provides-Extra: test
Provides-Extra: signatures
Provides-Extra: faster-signatures
Provides-Extra: faster-signatures
Requires-Dist: ed25519ll; extra == 'faster-signatures'
Provides-Extra: signatures
Requires-Dist: keyring; extra == 'signatures'
Requires-Dist: keyrings.alt; extra == 'signatures'
Provides-Extra: signatures
Requires-Dist: pyxdg; (sys_platform!="win32") and extra == 'signatures'
Provides-Extra: test
Requires-Dist: pytest (>=3.0.0); extra == 'test'
Requires-Dist: pytest-cov; extra == 'test'
```

"test" and "faster-signatures" are mentioned twice, and "signatures" is mentioned three times!