### PR TITLE
Add a few additional common patterns for legal and attribution files

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -30,9 +30,10 @@ distributable artifact of the project. By default, ``wheel`` conveniently
 includes files matching the following glob_ patterns in the ``.dist-info``
 directory:
 
+* ``AUTHORS*``
+* ``COPYING*``
 * ``LICEN[CS]E*``
-* ``COPYING``
-* ``NOTICE``
+* ``NOTICE*``
 
 This can be overridden by setting the ``license_files`` option in the
 ``[metadata]`` section of the project's ``setup.cfg``. For example:

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -14,7 +14,8 @@ DEFAULT_FILES = {
     'dummy_dist-1.0.dist-info/RECORD'
 }
 DEFAULT_LICENSE_FILES = {
-    'LICENSE', 'LICENSE.txt', 'LICENCE', 'LICENSE.txt', 'COPYING', 'NOTICE'
+    'LICENSE', 'LICENSE.txt', 'LICENCE', 'LICENSE.txt', 'COPYING',
+    'COPYING.md', 'NOTICE', 'NOTICE.rst', 'AUTHORS', 'AUTHORS.txt'
 }
 
 

--- a/wheel/bdist_wheel.py
+++ b/wheel/bdist_wheel.py
@@ -296,7 +296,7 @@ class bdist_wheel(Command):
             files.add(metadata['license_file'][1])
 
         if 'license_file' not in metadata and 'license_files' not in metadata:
-            patterns = 'LICEN[CS]E*', 'COPYING', 'NOTICE'
+            patterns = ('LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*')
 
         for pattern in patterns:
             for path in iglob(pattern):


### PR DESCRIPTION
This is a minor refinement to the default license/legal-related globs included in #138 , adding extension support for COPYING and NOTICE as well (since the former is often encountered with extensions, e.g. ``.txt``, ``.md``, ``.rst``; and the Apache license allows ``.txt`` as well as an extension), and also adds AUTHORS* as licenses have varying attribution requirements and they are sometimes included by reference in the licenses themselves as well. It also adds them in the docs (sorting the list alphabetically there) and adds some additional test filenames to cover these cases with varied extensions in the tests.