### PR TITLE
fix handling of extras

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -6,14 +6,18 @@ def test_pkginfo_to_metadata(tmpdir):
         ('Metadata-Version', '2.1'),
         ('Name', 'spam'),
         ('Version', '0.1'),
-        ('Provides-Extra', 'test'),
-        ('Provides-Extra', 'signatures'),
-        ('Provides-Extra', 'faster-signatures'),
         ('Requires-Dist', "pip @ https://github.com/pypa/pip/archive/1.3.1.zip"),
+        ('Requires-Dist', 'pywin32; sys_platform=="win32"'),
+        ('Provides-Extra', 'signatures'),
+        ('Requires-Dist', 'pyxdg; (sys_platform!="win32") and extra == \'signatures\''),
+        ('Provides-Extra', 'empty_extra'),
+        ('Provides-Extra', 'faster-signatures'),
         ('Requires-Dist', "ed25519ll; extra == 'faster-signatures'"),
+        ('Provides-Extra', 'rest'),
+        ('Requires-Dist', "docutils (>=0.8); extra == 'rest'"),
         ('Requires-Dist', "keyring; extra == 'signatures'"),
         ('Requires-Dist', "keyrings.alt; extra == 'signatures'"),
-        ('Requires-Dist', 'pyxdg; (sys_platform!="win32") and extra == \'signatures\''),
+        ('Provides-Extra', 'test'),
         ('Requires-Dist', "pytest (>=3.0.0); extra == 'test'"),
         ('Requires-Dist', "pytest-cov; extra == 'test'"),
     ]
@@ -23,22 +27,33 @@ def test_pkginfo_to_metadata(tmpdir):
 Metadata-Version: 0.0
 Name: spam
 Version: 0.1
+Provides-Extra: empty+extra
 Provides-Extra: test
+Provides-Extra: reST
 Provides-Extra: signatures
+Provides-Extra: Signatures
 Provides-Extra: faster-signatures""")
 
     egg_info_dir = tmpdir.ensure_dir('test.egg-info')
     egg_info_dir.join('requires.txt').write("""\
 pip@https://github.com/pypa/pip/archive/1.3.1.zip
 
+[empty+extra]
+
+[:sys_platform=="win32"]
+pywin32
+
 [faster-signatures]
 ed25519ll
+
+[reST]
+docutils>=0.8
 
 [signatures]
 keyring
 keyrings.alt
 
-[signatures:sys_platform!="win32"]
+[Signatures:sys_platform!="win32"]
 pyxdg
 
 [test]

--- a/wheel/metadata.py
+++ b/wheel/metadata.py
@@ -49,10 +49,11 @@ def generate_requirements(extras_require):
     """
     for extra, depends in extras_require.items():
         condition = ''
-        if extra and ':' in extra:  # setuptools extra:condition syntax
+        extra = extra or ''
+        if ':' in extra:  # setuptools extra:condition syntax
             extra, condition = extra.split(':', 1)
-            extra = pkg_resources.safe_extra(extra)
 
+        extra = pkg_resources.safe_extra(extra)
         if extra:
             yield 'Provides-Extra', extra
             if condition:
@@ -72,6 +73,9 @@ def pkginfo_to_metadata(egg_info_path, pkginfo_path):
     """
     pkg_info = read_pkg_info(pkginfo_path)
     pkg_info.replace_header('Metadata-Version', '2.1')
+    # Those will be regenerated from `requires.txt`.
+    del pkg_info['Provides-Extra']
+    del pkg_info['Requires-Dist']
     requires_path = os.path.join(egg_info_path, 'requires.txt')
     if os.path.exists(requires_path):
         with open(requires_path) as requires_file:


### PR DESCRIPTION
Ensure extras are properly canonicalized, so corresponding `Provides-Dist` markers will match with the list of extras returned by pkg_resources. See https://github.com/pypa/pip/issues/4617.