### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: pip
 
 stages:
   - name: test
-  - name: deploy to pypi
+  - name: deploy to PyPI
     if: type = push AND tag =~ ^\d+\.\d+\.\d+
 
 jobs:

--- a/docs/story.rst
+++ b/docs/story.rst
@@ -36,7 +36,7 @@ is still complicated, but installation is simple.
 With the binary package strategy people who want to install use a simple,
 compatible installer, and people who want to package use whatever is
 convenient for them for as long as it meets their needs. No one has
-to rewrite `setup.py` for their own or the 20k+ other packages on PyPi
+to rewrite `setup.py` for their own or the 20k+ other packages on PyPI
 unless a different build system does a better job.
 
 Wheel is my attempt to benefit from the excellent distutils-sig work


### PR DESCRIPTION
As spelled on https://pypi.org/.