### PR TITLE
fix support for Python 2.7

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+**UNRELEASED**
+
+- Fix support for Python 2.7: `hashlib.algorithms_available` was only added in 2.7.9.
+
 **0.32.0**
 
 - Removed wheel signing and verifying features

--- a/wheel/wheelfile.py
+++ b/wheel/wheelfile.py
@@ -63,9 +63,12 @@ class WheelFile(ZipFile):
                     path, hash_sum, size = line.rsplit(u',', 2)
                     if hash_sum:
                         algorithm, hash_sum = hash_sum.split(u'=')
-                        if algorithm not in hashlib.algorithms_available:
+                        try:
+                            hashlib.new(algorithm)
+                        except ValueError:
                             raise WheelError('Unsupported hash algorithm: {}'.format(algorithm))
-                        elif algorithm.lower() in {'md5', 'sha1'}:
+
+                        if algorithm.lower() in {'md5', 'sha1'}:
                             raise WheelError(
                                 'Weak hash algorithm ({}) is not permitted by PEP 427'
                                 .format(algorithm))


### PR DESCRIPTION
`hashlib.algorithms_available` was only added in 2.7.9. Fix #258.