### PR TITLE
fix exceptions with older versions of setuptools

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,6 +3,7 @@ Release Notes
 
 **UNRELEASED**
 
+- Fix exception with setuptools/pkg_resources versions older than 18.8.
 - Fix support for Python 2.7: `hashlib.algorithms_available` was only added in 2.7.9.
 
 **0.32.0**

--- a/wheel/metadata.py
+++ b/wheel/metadata.py
@@ -18,7 +18,7 @@ EXTRA_RE = re.compile(
 
 def requires_to_requires_dist(requirement):
     """Return the version specifier for a requirement in PEP 345/566 fashion."""
-    if requirement.url:
+    if getattr(requirement, 'url', None):
         return " @ " + requirement.url
 
     requires_dist = []


### PR DESCRIPTION
Support for direct URL in requirements was added in 18.8 (with the switch to packaging for parsing requirements). Fix #257.