### PR TITLE
Fix: two .dist-info directories when using --build-number

### DIFF
--- a/tests/test_tagopt.py
+++ b/tests/test_tagopt.py
@@ -3,8 +3,10 @@ Tests for the bdist_wheel tag options (--python-tag, --universal, and
 --plat-name)
 """
 
+import os
 import subprocess
 import sys
+import zipfile
 
 import pytest
 
@@ -57,6 +59,9 @@ def test_build_number(temp_pkg):
     assert len(wheels) == 1
     assert (wheels[0].basename == 'Test-1.0-1-py%s-none-any.whl' % (sys.version[0],))
     assert wheels[0].ext == '.whl'
+    with zipfile.ZipFile(str(wheels[0])) as wheel:
+        distinfo_dirs = set(filter(None, (os.path.split(x)[0] for x in wheel.namelist())))
+    assert len(distinfo_dirs) == 1
 
 
 def test_explicit_tag(temp_pkg):

--- a/wheel/wheelfile.py
+++ b/wheel/wheelfile.py
@@ -42,7 +42,7 @@ class WheelFile(ZipFile):
         super(WheelFile, self).__init__(file, mode, compression=ZIP_DEFLATED, allowZip64=True)
 
         self.dist_info_path = '{}.dist-info'.format(
-            '-'.join(filter(bool, self.parsed_filename.group('namever', 'build')))
+            '-'.join(filter(None, self.parsed_filename.group('namever', 'build')))
         )
         self.record_path = self.dist_info_path + '/RECORD'
         self._file_hashes = OrderedDict()

--- a/wheel/wheelfile.py
+++ b/wheel/wheelfile.py
@@ -41,7 +41,11 @@ class WheelFile(ZipFile):
 
         super(WheelFile, self).__init__(file, mode, compression=ZIP_DEFLATED, allowZip64=True)
 
-        self.dist_info_path = '{}.dist-info'.format(self.parsed_filename.group('namever'))
+        build = self.parsed_filename.group('build')
+        if build:
+            self.dist_info_path = '{namever}-{build}.dist-info'.format(**self.parsed_filename.groupdict())
+        else:
+            self.dist_info_path = '{namever}.dist-info'.format(**self.parsed_filename.groupdict())
         self.record_path = self.dist_info_path + '/RECORD'
         self._file_hashes = OrderedDict()
         self._file_sizes = {}

--- a/wheel/wheelfile.py
+++ b/wheel/wheelfile.py
@@ -41,11 +41,9 @@ class WheelFile(ZipFile):
 
         super(WheelFile, self).__init__(file, mode, compression=ZIP_DEFLATED, allowZip64=True)
 
-        build = self.parsed_filename.group('build')
-        if build:
-            self.dist_info_path = '{namever}-{build}.dist-info'.format(**self.parsed_filename.groupdict())
-        else:
-            self.dist_info_path = '{namever}.dist-info'.format(**self.parsed_filename.groupdict())
+        self.dist_info_path = '{}.dist-info'.format(
+            '-'.join(filter(bool, self.parsed_filename.group('namever', 'build')))
+        )
         self.record_path = self.dist_info_path + '/RECORD'
         self._file_hashes = OrderedDict()
         self._file_sizes = {}


### PR DESCRIPTION
Fixes #263 