### PR TITLE
egg2wheel: Remove period from pyver in wheel filename

### DIFF
--- a/wheel/cli/convert.py
+++ b/wheel/cli/convert.py
@@ -57,7 +57,7 @@ def egg2wheel(egg_path, dest_dir):
 
     pyver = egg_info['pyver']
     if pyver:
-        pyver = pyver.replace('.', '')
+        pyver = egg_info['pyver'] = pyver.replace('.', '')
 
     arch = (egg_info['arch'] or 'any').replace('.', '_').replace('-', '_')
 


### PR DESCRIPTION
When converting an egg to a wheel, the period in the pyver component is correctly removed for the purposes of calculating the ABI tag and `WHEEL` tag, but the period is not removed from `egg_info['pyver']`, leading to an extraneous period being present when the wheel filename is computed with `'{name}-{ver}-{pyver}-{}-{}.whl'.format(abi, arch, **egg_info)`.

As a result, running `wheel convert` on an egg named, say, `foo-0.1.0-py3.5.egg` currently produces a wheel named `foo-0.1.0-py3.5-none-any.whl`, which is invalid (or, at the very least, inaccurate) due to the period in the pyversion tag.

This patch fixes that.