### PR TITLE
fix handling of direct URL requirements with markers

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -7,19 +7,22 @@ def test_pkginfo_to_metadata(tmpdir):
         ('Name', 'spam'),
         ('Version', '0.1'),
         ('Requires-Dist', "pip @ https://github.com/pypa/pip/archive/1.3.1.zip"),
-        ('Requires-Dist', 'pywin32; sys_platform=="win32"'),
+        ('Requires-Dist', 'pywin32 ; sys_platform=="win32"'),
+        ('Requires-Dist', 'foo @ http://host/foo.zip ; sys_platform=="win32"'),
         ('Provides-Extra', 'signatures'),
-        ('Requires-Dist', 'pyxdg; (sys_platform!="win32") and extra == \'signatures\''),
+        ('Requires-Dist', 'pyxdg ; (sys_platform!="win32") and extra == \'signatures\''),
         ('Provides-Extra', 'empty_extra'),
+        ('Provides-Extra', 'extra'),
+        ('Requires-Dist', 'bar @ http://host/bar.zip ; extra == \'extra\''),
         ('Provides-Extra', 'faster-signatures'),
-        ('Requires-Dist', "ed25519ll; extra == 'faster-signatures'"),
+        ('Requires-Dist', "ed25519ll ; extra == 'faster-signatures'"),
         ('Provides-Extra', 'rest'),
-        ('Requires-Dist', "docutils (>=0.8); extra == 'rest'"),
-        ('Requires-Dist', "keyring; extra == 'signatures'"),
-        ('Requires-Dist', "keyrings.alt; extra == 'signatures'"),
+        ('Requires-Dist', "docutils (>=0.8) ; extra == 'rest'"),
+        ('Requires-Dist', "keyring ; extra == 'signatures'"),
+        ('Requires-Dist', "keyrings.alt ; extra == 'signatures'"),
         ('Provides-Extra', 'test'),
-        ('Requires-Dist', "pytest (>=3.0.0); extra == 'test'"),
-        ('Requires-Dist', "pytest-cov; extra == 'test'"),
+        ('Requires-Dist', "pytest (>=3.0.0) ; extra == 'test'"),
+        ('Requires-Dist', "pytest-cov ; extra == 'test'"),
     ]
 
     pkg_info = tmpdir.join('PKG-INFO')
@@ -38,10 +41,14 @@ Provides-Extra: faster-signatures""")
     egg_info_dir.join('requires.txt').write("""\
 pip@https://github.com/pypa/pip/archive/1.3.1.zip
 
+[extra]
+bar @ http://host/bar.zip
+
 [empty+extra]
 
 [:sys_platform=="win32"]
 pywin32
+foo @http://host/foo.zip
 
 [faster-signatures]
 ed25519ll

--- a/wheel/metadata.py
+++ b/wheel/metadata.py
@@ -62,7 +62,7 @@ def generate_requirements(extras_require):
             condition += "extra == '%s'" % extra
 
         if condition:
-            condition = '; ' + condition
+            condition = ' ; ' + condition
 
         for new_req in convert_requirements(depends):
             yield 'Requires-Dist', new_req + condition


### PR DESCRIPTION
There must be at least one space between the URL and the `;` delimiting the markers, as per PEP 508:
```
name_req      = name wsp* extras? wsp* versionspec? wsp* quoted_marker?
url_req       = name wsp* extras? wsp* urlspec wsp+ quoted_marker?
```

Note: there seems to be an unused `EXTRA_RE` variable in [`wheel/metadata.py`](https://github.com/pypa/wheel/blob/master/wheel/metadata.py#L15).