### PR TITLE
Fix flake8 warning "W605 invalid escape sequence '...'"

### DIFF
--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -20,5 +20,5 @@ def test_convert_egg(egg_paths, tmpdir):
     wheel_names = [path.basename for path in tmpdir.listdir()]
     assert len(wheel_names) == len(egg_paths)
     assert all(WHEEL_INFO_RE.match(filename) for filename in wheel_names)
-    assert all(re.match('^[\w\d.]+-\d\.\d-\w+\d+-[\w\d]+-[\w\d]+\.whl$', fname)
+    assert all(re.match(r'^[\w\d.]+-\d\.\d-\w+\d+-[\w\d]+-[\w\d]+\.whl$', fname)
                for fname in wheel_names)


### PR DESCRIPTION
Fixes Travis CI failure.

Invalid escape sequences are deprecated since Python 3.6 and will be a syntax error in a future release. For details, see:

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior

> A backslash-character pair that is not a valid escape sequence now generates a DeprecationWarning. Although this will eventually become a SyntaxError, that will not be for several Python releases.