### PR TITLE
Mention setting PYTHONPATH in dev guide

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,7 +4,7 @@ Development
 Pull Requests
 -------------
 
-- Submit Pull Requests against the `master` branch.
+- Submit Pull Requests against the ``master`` branch.
 - Provide a good description of what you're doing and why.
 - Provide tests that cover your changes and try to run the tests locally first.
 
@@ -48,24 +48,27 @@ another change to the pull branch.
 .. _.travis.yml file: https://github.com/pypa/wheel/blob/master/.travis.yml
 .. _travis pull requests page: https://travis-ci.org/pypa/wheel/pull_requests
 
-Running Tests
--------------
+Running Tests Locally
+---------------------
 
 Python requirements: tox_ or pytest_
 
-To run the tests locally::
+To run the tests via tox::
 
   $ tox                     # Runs the tests against all matching interpreters
+
   $ tox -e py35             # Runs the tests against a specific environment
+
+To run the tests via pytest::
+
   $ pip install -e .[test]  # Installs the test dependencies locally
   $ pytest                  # Runs the tests with the current interpreter
 
-If using pytest, be sure to add the project root to the ``PYTHONPATH``, e.g.::
-
-  $ export PYTHONPATH="$PWD:$PYTHONPATH"
+The above pip install command will replace the current interpreter's installed wheel package with the development package being tested. If you use this workflow, it is recommended to run it under a virtualenv_.
 
 .. _tox: https://pypi.org/project/tox/
 .. _pytest: https://pypi.org/project/pytest/
+.. _virtualenv: https://pypi.org/project/virtualenv/
 
 Getting Involved
 ----------------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -60,6 +60,10 @@ To run the tests locally::
   $ pip install -e .[test]  # Installs the test dependencies locally
   $ pytest                  # Runs the tests with the current interpreter
 
+If using pytest, be sure to add the project root to the ``PYTHONPATH``, e.g.::
+
+  $ export PYTHONPATH="$PWD:$PYTHONPATH"
+
 .. _tox: https://pypi.org/project/tox/
 .. _pytest: https://pypi.org/project/pytest/
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -57,6 +57,8 @@ To run the tests via tox::
 
   $ tox                     # Runs the tests against all matching interpreters
 
+::
+
   $ tox -e py35             # Runs the tests against a specific environment
 
 To run the tests via pytest::

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -53,20 +53,22 @@ Running Tests Locally
 
 Python requirements: tox_ or pytest_
 
-To run the tests via tox::
+To run the tests via tox against all matching interpreters::
 
-  $ tox                     # Runs the tests against all matching interpreters
+  $ tox
 
-::
+To run the tests via tox against a specific environment::
 
-  $ tox -e py35             # Runs the tests against a specific environment
+  $ tox -e py35
 
-To run the tests via pytest::
+Alternatively, you can run the tests via pytest using your default interpreter::
 
-  $ pip install -e .[test]  # Installs the test dependencies locally
+  $ pip install -e .[test]  # Installs the test dependencies
   $ pytest                  # Runs the tests with the current interpreter
 
-The above pip install command will replace the current interpreter's installed wheel package with the development package being tested. If you use this workflow, it is recommended to run it under a virtualenv_.
+The above pip install command will replace the current interpreter's installed
+wheel package with the development package being tested. If you use this
+workflow, it is recommended to run it under a virtualenv_.
 
 .. _tox: https://pypi.org/project/tox/
 .. _pytest: https://pypi.org/project/pytest/


### PR DESCRIPTION
In my case, while trying to setup my local environment to get a passing test suite (and without using tox), I had failures from wheel not being on the path. I had erroneously used `export PYTHONPATH=.` but that didn't work for tests that change the working directory. In desperation I actually installed a released version of wheel to the system python because I wasn't sure whether it was somehow required for bootstrapping the tests. Of course, due to version mismatches this left me in a state where some tests passed and others failed.

This PR simply advises the developer to put $PWD on the python path before running pytest.