### PR TITLE
Correct default license file 'LICENCE.txt'

### DIFF
--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -14,7 +14,7 @@ DEFAULT_FILES = {
     'dummy_dist-1.0.dist-info/RECORD'
 }
 DEFAULT_LICENSE_FILES = {
-    'LICENSE', 'LICENSE.txt', 'LICENCE', 'LICENSE.txt', 'COPYING',
+    'LICENSE', 'LICENSE.txt', 'LICENCE', 'LICENCE.txt', 'COPYING',
     'COPYING.md', 'NOTICE', 'NOTICE.rst', 'AUTHORS', 'AUTHORS.txt'
 }
 


### PR DESCRIPTION
Before it mistakenly duplicated 'LICENSE.txt'.