### PR TITLE
Sorting requirement extras to ensure deterministic builds

### DIFF
--- a/wheel/metadata.py
+++ b/wheel/metadata.py
@@ -34,7 +34,7 @@ def convert_requirements(requirements):
     for req in requirements:
         parsed_requirement = pkg_resources.Requirement.parse(req)
         spec = requires_to_requires_dist(parsed_requirement)
-        extras = ",".join(parsed_requirement.extras)
+        extras = ",".join(sorted(parsed_requirement.extras))
         if extras:
             extras = "[%s]" % extras
         yield (parsed_requirement.project_name + extras + spec)


### PR DESCRIPTION
This fix will ensure METADATA files generated by wheel will be deterministic. 

I noticed this issue while working with `apache-airflow==1.9.0` package, the METADATA file changes between installations (in python3.6):
```
$> diff /tmp/cache/apache_airflow_1/apache_airflow-1.9.0.dist-info/METADATA /tmp/cache/apache_airflow_2/apache_airflow-1.9.0.dist-info/METADATA 
171c171
< Requires-Dist: hdfs[kerberos,dataframe,avro] (>=2.0.4) ; extra == 'devel_hadoop'
---
> Requires-Dist: hdfs[avro,kerberos,dataframe] (>=2.0.4) ; extra == 'devel_hadoop'
248c248
< Requires-Dist: hdfs[kerberos,dataframe,avro] (>=2.0.4) ; extra == 'webhdfs'
---
> Requires-Dist: hdfs[avro,kerberos,dataframe] (>=2.0.4) ; extra == 'webhdfs'
```

The fix was added the same way as this previous fix: https://github.com/pypa/wheel/commit/bea1108397406253942e36ea8a6529ef016ad057