### PR TITLE
wheelfile: Mask platform specific mode bits

### DIFF
--- a/wheel/wheelfile.py
+++ b/wheel/wheelfile.py
@@ -4,6 +4,7 @@ import csv
 import hashlib
 import os.path
 import re
+import stat
 import time
 from collections import OrderedDict
 from distutils import log as logger
@@ -138,14 +139,14 @@ class WheelFile(ZipFile):
             data = f.read()
 
         zinfo = ZipInfo(arcname or filename, date_time=get_zipinfo_datetime(st.st_mtime))
-        zinfo.external_attr = st.st_mode << 16
+        zinfo.external_attr = (stat.S_IMODE(st.st_mode) | stat.S_IFMT(st.st_mode)) << 16
         zinfo.compress_type = ZIP_DEFLATED
         self.writestr(zinfo, data, compress_type)
 
     def mkdir(self, filename, arcname):
         st = os.stat(filename)
         zinfo = ZipInfo(arcname + '/', date_time=get_zipinfo_datetime(st.st_mtime))
-        zinfo.external_attr = st.st_mode << 16
+        zinfo.external_attr = (stat.S_IMODE(st.st_mode) | stat.S_IFMT(st.st_mode)) << 16
         zinfo.compress_type = ZIP_DEFLATED
         self.writestr(zinfo, b'')
 


### PR DESCRIPTION
When creating zip entries for files and directories, only attempt to
preserve the subset of mode bits which can be reapplied through chmod,
plus the file type bits.  This will exclude any bits that are platform-
or filesystem-specific, like S_IFJOURNAL on AIX.

Fixes #291 