### PR TITLE
Don't append "m" ABI flag in Python 3.8

### DIFF
--- a/wheel/pep425tags.py
+++ b/wheel/pep425tags.py
@@ -81,7 +81,9 @@ def get_abi_tag():
             d = 'd'
         if get_flag('WITH_PYMALLOC',
                     lambda: impl == 'cp',
-                    warn=(impl == 'cp')):
+                    warn=(impl == 'cp' and
+                          sys.version_info < (3, 8))) \
+                and sys.version_info < (3, 8):
             m = 'm'
         if get_flag('Py_UNICODE_SIZE',
                     lambda: sys.maxunicode == 0x10ffff,


### PR DESCRIPTION
In Python 3.8, the `m` flag is no longer appended to the SOABI, since the ABI is longer influenced by enabling pymalloc.  This PR should fix the ability to install Python 3.8 wheels on Windows.  In Python 3.8, `sys.abiflags` is an empty string.

https://docs.python.org/dev/whatsnew/3.8.html#build-and-c-api-changes
https://bugs.python.org/issue36707

See also pypa/pip#6874