### PR TITLE
Docs: license_file was deprecated in wheel v0.32

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -52,7 +52,7 @@ By specifying an empty ``license_files`` option, you can disable this
 functionality entirely.
 
 .. note:: There used to be an option called ``license_file`` (singular).
-    As of wheel v1.0, this option has been deprecated in favor of the more
+    As of wheel v0.32, this option has been deprecated in favor of the more
     versatile ``license_files`` option.
 
 .. _glob: https://docs.python.org/library/glob.html


### PR DESCRIPTION
> **0.32.0 (2018-09-29)**
> ...
> * Allowed multiple license files to be specified using the `license_files` option
> * Deprecated the `license_file` option

https://wheel.readthedocs.io/en/stable/news.html