### PR TITLE
Issue #329: Remove last remnant of custom PyPy tags

### DIFF
--- a/src/wheel/pep425tags.py
+++ b/src/wheel/pep425tags.py
@@ -45,7 +45,7 @@ def get_abbr_impl():
 def get_impl_ver():
     """Return implementation version."""
     impl_ver = get_config_var("py_version_nodot")
-    if not impl_ver or get_abbr_impl() == 'pp':
+    if not impl_ver:
         impl_ver = ''.join(map(str, get_impl_version_info()))
     return impl_ver
 


### PR DESCRIPTION
The resolution of issue #328 removed the custom PyPy tagging
from `get_impl_version_info()`, this just cleans up the check
that forces PyPy to call that even if `py_version_nodot` was
already set.