### PR TITLE
Ignore files terminating in ~.

### DIFF
--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -340,7 +340,7 @@ class bdist_wheel(Command):
         for pattern in patterns:
             for path in iglob(pattern):
                 if path.endswith('~'):
-                    logger.debug('ignoring license file "%s" as it looks like a backup.', path)
+                    logger.debug('ignoring license file "%s" as it looks like a backup', path)
                     continue
 
                 if path not in files and os.path.isfile(path):

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -339,6 +339,10 @@ class bdist_wheel(Command):
 
         for pattern in patterns:
             for path in iglob(pattern):
+                if path.endswith('~'):
+                    logger.debug('ignoring license file "%s" as it looks like a backup.', path)
+                    continue
+
                 if path not in files and os.path.isfile(path):
                     logger.info('adding license file "%s" (matched pattern "%s")', path, pattern)
                     files.add(path)

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -21,6 +21,9 @@ DEFAULT_LICENSE_FILES = {
     'LICENSE', 'LICENSE.txt', 'LICENCE', 'LICENCE.txt', 'COPYING',
     'COPYING.md', 'NOTICE', 'NOTICE.rst', 'AUTHORS', 'AUTHORS.txt'
 }
+OTHER_IGNORED_FILES = {
+    'LICENSE~', 'AUTHORS~',
+}
 
 
 @pytest.fixture
@@ -34,7 +37,7 @@ setup(
     version='1.0'
 )
 """)
-    for fname in DEFAULT_LICENSE_FILES:
+    for fname in DEFAULT_LICENSE_FILES | OTHER_IGNORED_FILES:
         basedir.join(fname).write('')
 
     basedir.join('licenses').mkdir().join('DUMMYFILE').write('')


### PR DESCRIPTION
This is Unix's most common pattern for backup files. They are often
present, but I can't think of a good reason for them to be distributed.