### PR TITLE
Updated link to now-decommissioned mailing list

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -90,7 +90,7 @@ To make a new release:
 #. Replace the ``__version__`` attribute in ``src/wheel/__init__.py`` with the
    same version number as above (without the date of course).
 #. Create a new git tag matching the version exactly
-#. Push the new tag to Github
+#. Push the new tag to GitHub
 
-Pushing a new tag to Github will trigger the publish workflow which package the
+Pushing a new tag to GitHub will trigger the publish workflow which package the
 project and publish the resulting artifacts to PyPI.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@ wheel
 =====
 
 `User list <http://groups.google.com/group/python-virtualenv>`_ |
-`Dev list <http://groups.google.com/group/pypa-dev>`_ |
-`Github <https://github.com/pypa/wheel>`_ |
+`Dev list <https://mail.python.org/archives/list/distutils-sig@python.org/>`_ |
+`GitHub <https://github.com/pypa/wheel>`_ |
 `PyPI <https://pypi.org/pypi/wheel/>`_ |
 User IRC: #pypa |
 Dev IRC: #pypa-dev


### PR DESCRIPTION
Per https://groups.google.com/d/msg/pypa-dev/rUNsfIbruHM/LCEx-CB5AgAJ , pointing to distutils-sig instead.