### PR TITLE
adapt for upcoming changes in PyPy's SOABI tag

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,10 +7,10 @@ Release Notes
 - Updated vendored ``packaging`` library to v20.7
 - Switched to always using LF as line separator when generating ``WHEEL`` files
   (on Windows, CRLF was being used instead)
-- The ABI tag is taken from  the sysconfig SOABI valuer. On PyPy the SOABI
-  value is ``pypy37-pp73`` which is not compliant with PEP 3149, it should have
-  both the API tag and the platform tag. Future-proof any change in PyPy's
-  SOABI tag to make sure only the ABI tag is used by wheel.
+- The ABI tag is taken from  the sysconfig SOABI value. On PyPy the SOABI value
+  is ``pypy37-pp73`` which is not compliant with PEP 3149, as it should have
+  both the API tag and the platform tag. This change future-proofs any change
+  in PyPy's SOABI tag to make sure only the ABI tag is used by wheel.
 
 **0.35.1 (2020-08-14)**
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,12 +7,10 @@ Release Notes
 - Updated vendored ``packaging`` library to v20.7
 - Switched to always using LF as line separator when generating ``WHEEL`` files
   (on Windows, CRLF was being used instead)
-- When calculating the ABI tag from  the sysconfig SOABI value, CPython
-  takes only the second field. This is to accomocate CPython's SOABI
-  value which looks like ``'cpython-37m-x86_64-linux-gnu`` where the desired
-  ABI tag is ``cp-37m``. On PyPy the SOABI value is ``pypy37-pp73`` and the
-  desired ABI tag is ``pypy37-pp73``, so we take the first two fields
-  unchanged.
+- The ABI tag is taken from  the sysconfig SOABI valuer. On PyPy the SOABI
+  value is ``pypy37-pp73`` which is not compliant with PEP 3149, it should have
+  both the API tag and the platform tag. Future-proof any change in PyPy's
+  SOABI tag to make sure only the ABI tag is used by wheel.
 
 **0.35.1 (2020-08-14)**
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,12 @@ Release Notes
 - Updated vendored ``packaging`` library to v20.7
 - Switched to always using LF as line separator when generating ``WHEEL`` files
   (on Windows, CRLF was being used instead)
+- When calculating the ABI tag from  the sysconfig SOABI value, CPython
+  takes only the second field. This is to accomocate CPython's SOABI
+  value which looks like ``'cpython-37m-x86_64-linux-gnu`` where the desired
+  ABI tag is ``cp-37m``. On PyPy the SOABI value is ``pypy37-pp73`` and the
+  desired ABI tag is ``pypy37-pp73``, so we take the first two fields
+  unchanged.
 
 **0.35.1 (2020-08-14)**
 

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -97,6 +97,10 @@ def get_abi_tag():
         abi = '%s%s%s%s%s' % (impl, tags.interpreter_version(), d, m, u)
     elif soabi and soabi.startswith('cpython-'):
         abi = 'cp' + soabi.split('-')[1]
+    elif soabi and soabi.startswith('pypy-'):
+        # we want something like pypy36-pp73
+        abi = '-'.join(soabi.split('-')[:2])
+        abi = abi.replace('.', '_').replace('-', '_')
     elif soabi:
         abi = soabi.replace('.', '_').replace('-', '_')
     else:

--- a/tests/test_tagopt.py
+++ b/tests/test_tagopt.py
@@ -44,9 +44,6 @@ def temp_pkg(request, tmpdir):
             pytest.skip('Cannot compile C extensions')
     return tmpdir
 
-@pytest.mark.parametrize('temp_pkg', [[True, 'xxx']], indirect=['temp_pkg'])
-def test_nocompile_skips(temp_pkg):
-    assert False  # should have skipped with a "Cannot compile" message
 
 @pytest.mark.parametrize('temp_pkg', [[True, 'xxx']], indirect=['temp_pkg'])
 def test_nocompile_skips(temp_pkg):

--- a/tests/test_tagopt.py
+++ b/tests/test_tagopt.py
@@ -44,6 +44,9 @@ def temp_pkg(request, tmpdir):
             pytest.skip('Cannot compile C extensions')
     return tmpdir
 
+@pytest.mark.parametrize('temp_pkg', [[True, 'xxx']], indirect=['temp_pkg'])
+def test_nocompile_skips(temp_pkg):
+    assert False  # should have skipped with a "Cannot compile" message
 
 @pytest.mark.parametrize('temp_pkg', [[True, 'xxx']], indirect=['temp_pkg'])
 def test_nocompile_skips(temp_pkg):


### PR DESCRIPTION
Closes #372. PyPy currently has a SOABI tag like `pypy36-pp73` (only the ABI tag) but according to PEP 3149 it should be `pypy36-pp73-x86_64-linux-gnu` (ABI tag - platform tag). PyPy may change this in an upcoming release.

This should be forward compatible, as long as the ABI tag contains a single `-`.