### PR TITLE
fix regression in setting plat-name

### DIFF
--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -273,7 +273,8 @@ class bdist_wheel(Command):
             else:
                 abi_tag = str(get_abi_tag()).lower()
             tag = (impl, abi_tag, plat_name)
-            supported_tags = [(t.interpreter, t.abi, t.platform)
+            # issue gh-374: allow overriding plat_name
+            supported_tags = [(t.interpreter, t.abi, plat_name)
                               for t in tags.sys_tags()]
             assert tag in supported_tags, "would build wheel with unsupported tag {}".format(tag)
         return tag

--- a/tests/test_tagopt.py
+++ b/tests/test_tagopt.py
@@ -44,9 +44,11 @@ def temp_pkg(request, tmpdir):
             pytest.skip('Cannot compile C extensions')
     return tmpdir
 
+
 @pytest.mark.parametrize('temp_pkg', [[True, 'xxx']], indirect=['temp_pkg'])
 def test_nocompile_skips(temp_pkg):
     assert False  # should have skipped with a "Cannot compile" message
+
 
 def test_default_tag(temp_pkg):
     subprocess.check_call([sys.executable, 'setup.py', 'bdist_wheel'], cwd=str(temp_pkg))

--- a/tests/test_tagopt.py
+++ b/tests/test_tagopt.py
@@ -27,16 +27,26 @@ EXT_MODULES = "ext_modules=[Extension('_test', sources=['test.c'])],"
 def temp_pkg(request, tmpdir):
     tmpdir.join('test.py').write('print("Hello, world")')
 
-    ext = getattr(request, 'param', False)
-    if ext:
-        tmpdir.join('test.c').write('#include <stdio.h>')
+    ext = getattr(request, 'param', [False, ''])
+    if ext[0]:
+        # if ext[1] is not '', it will write a bad header and fail to compile
+        tmpdir.join('test.c').write('#include <std%sio.h>' % ext[1])
         setup_py = SETUP_PY.format(ext_modules=EXT_MODULES)
     else:
         setup_py = SETUP_PY.format(ext_modules='')
 
     tmpdir.join('setup.py').write(setup_py)
+    if ext[0]:
+        try:
+            subprocess.check_call(
+                [sys.executable, 'setup.py', 'build_ext'], cwd=str(tmpdir))
+        except subprocess.CalledProcessError:
+            pytest.skip('Cannot compile C extensions')
     return tmpdir
 
+@pytest.mark.parametrize('temp_pkg', [[True, 'xxx']], indirect=['temp_pkg'])
+def test_nocompile_skips(temp_pkg):
+    assert False  # should have skipped with a "Cannot compile" message
 
 def test_default_tag(temp_pkg):
     subprocess.check_call([sys.executable, 'setup.py', 'bdist_wheel'], cwd=str(temp_pkg))
@@ -146,14 +156,11 @@ def test_plat_name_purepy(temp_pkg):
     assert wheels[0].ext == '.whl'
 
 
-@pytest.mark.parametrize('temp_pkg', [True], indirect=['temp_pkg'])
+@pytest.mark.parametrize('temp_pkg', [[True, '']], indirect=['temp_pkg'])
 def test_plat_name_ext(temp_pkg):
-    try:
-        subprocess.check_call(
-            [sys.executable, 'setup.py', 'bdist_wheel', '--plat-name=testplat.arch'],
-            cwd=str(temp_pkg))
-    except subprocess.CalledProcessError:
-        pytest.skip("Cannot compile C Extensions")
+    subprocess.check_call(
+        [sys.executable, 'setup.py', 'bdist_wheel', '--plat-name=testplat.arch'],
+        cwd=str(temp_pkg))
 
     dist_dir = temp_pkg.join('dist')
     assert dist_dir.check(dir=1)
@@ -176,15 +183,12 @@ def test_plat_name_purepy_in_setupcfg(temp_pkg):
     assert wheels[0].ext == '.whl'
 
 
-@pytest.mark.parametrize('temp_pkg', [True], indirect=['temp_pkg'])
+@pytest.mark.parametrize('temp_pkg', [[True, '']], indirect=['temp_pkg'])
 def test_plat_name_ext_in_setupcfg(temp_pkg):
     temp_pkg.join('setup.cfg').write('[bdist_wheel]\nplat_name=testplat.arch')
-    try:
-        subprocess.check_call(
-            [sys.executable, 'setup.py', 'bdist_wheel'],
-            cwd=str(temp_pkg))
-    except subprocess.CalledProcessError:
-        pytest.skip("Cannot compile C Extensions")
+    subprocess.check_call(
+        [sys.executable, 'setup.py', 'bdist_wheel'],
+        cwd=str(temp_pkg))
 
     dist_dir = temp_pkg.join('dist')
     assert dist_dir.check(dir=1)


### PR DESCRIPTION
The first commit makes the fixture more specifically test for the ability to compile, and adds a test that triggers compilation failure to prove skipping works. The failing tests expose the problem in issue #374. A subsequent changeset to fix the tests is waiting for a decision whether to restore old behavior or change it.