### PR TITLE
Remove 'wheel install' docs

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -79,22 +79,8 @@ This can be changed with the ``--dest-dir`` option::
 Installing Wheels
 -----------------
 
-.. note:: The ``wheel install`` command is merely a Proof-Of-Concept
-    implementation and lacks many features provided by pip_. It is meant only
-    as an example for implementors of packaging tools. End users should use
-    ``pip install`` instead.
+To install a wheel file, use pip_::
 
-To install a wheel file in ``site-packages``::
-
-    $ wheel install someproject-1.5.0-py2-py3-none.whl
-
-This will unpack the archive in your current site packages directory and
-install any console scripts contained in the wheel.
-
-You can accomplish the same in two separate steps (with ``<site-packages-dir>``
-being the path to your ``site-packages`` directory::
-
-    $ wheel unpack -d <site-packages-dir> someproject-X.Y.Z-py2-py3-none.whl
-    $ wheel install-scripts someproject
+    $ pip install someproject-1.5.0-py2-py3-none.whl
 
 .. _pip: https://pypi.org/project/pip/


### PR DESCRIPTION
Fixes #376. The `wheel install` command was removed in https://github.com/pypa/wheel/commit/353217fb496d61b3c5ce287b9c61a229e2ed27fe.