### PR TITLE
Fixed CRLF being used when generating WHEEL files on Windows

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -5,6 +5,8 @@ Release Notes
 
 - Added official Python 3.9 support
 - Updated vendored ``packaging`` library to v20.7
+- Switched to always using LF as line separator when generating ``WHEEL`` files
+  (on Windows, CRLF was being used instead)
 
 **0.35.1 (2020-08-14)**
 

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -12,9 +12,9 @@ import sys
 import re
 import warnings
 from collections import OrderedDict
-from email.generator import Generator
 from distutils.core import Command
 from distutils import log as logger
+from io import BytesIO
 from glob import iglob
 from shutil import rmtree
 from sysconfig import get_config_var
@@ -29,6 +29,10 @@ from .vendored.packaging import tags
 from .wheelfile import WheelFile
 from . import __version__ as wheel_version
 
+if sys.version_info < (3,):
+    from email.generator import Generator as BytesGenerator
+else:
+    from email.generator import BytesGenerator
 
 safe_name = pkg_resources.safe_name
 safe_version = pkg_resources.safe_version
@@ -381,8 +385,10 @@ class bdist_wheel(Command):
 
         wheelfile_path = os.path.join(wheelfile_base, 'WHEEL')
         logger.info('creating %s', wheelfile_path)
-        with open(wheelfile_path, 'w') as f:
-            Generator(f, maxheaderlen=0).flatten(msg)
+        buffer = BytesIO()
+        BytesGenerator(buffer, maxheaderlen=0).flatten(msg)
+        with open(wheelfile_path, 'wb') as f:
+            f.write(buffer.getvalue().replace(b'\r\n', b'\r'))
 
     def _ensure_relative(self, path):
         # copied from dir_util, deleted

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -146,3 +146,11 @@ def test_compression(dummy_dist, monkeypatch, tmpdir, option, compress_type):
         assert 'dummy_dist-1.0.dist-info/METADATA' in filenames
         for zinfo in wf.filelist:
             assert zinfo.compress_type == compress_type
+
+
+def test_wheelfile_line_endings(wheel_paths):
+    for path in wheel_paths:
+        with WheelFile(path) as wf:
+            wheelfile = next(fn for fn in wf.filelist if fn.filename.endswith('WHEEL'))
+            wheelfile_contents = wf.read(wheelfile)
+            assert b'\r' not in wheelfile_contents


### PR DESCRIPTION
Fixes #378.