### PR TITLE
add support for inline markers/constraints

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-1
+  image_family: freebsd-12-2
 
 test_task:
   only_if: "$CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -23,6 +23,8 @@ def test_pkginfo_to_metadata(tmpdir):
         ('Provides-Extra', 'test'),
         ('Requires-Dist', "pytest (>=3.0.0) ; extra == 'test'"),
         ('Requires-Dist', "pytest-cov ; extra == 'test'"),
+        ('Requires-Dist', 'pywin32 (==300) ; (sys_platform == "win32") and extra == \'test\''),
+
     ]
 
     pkg_info = tmpdir.join('PKG-INFO')
@@ -65,7 +67,9 @@ pyxdg
 
 [test]
 pytest>=3.0.0
-pytest-cov""")
+pytest-cov
+pywin32==300; sys_platform == 'win32'
+""")
 
     message = pkginfo_to_metadata(egg_info_path=str(egg_info_dir), pkginfo_path=str(pkg_info))
     assert message.items() == expected_metadata


### PR DESCRIPTION
from reviewing the existing test it seems supported via a [:sys_platform=="win32"]
config header, but when listed inline bdist_wheel silently truncated and
tossed them. This adds support for inline
pywin32 (==300) ; (sys_platform == "win32"
 even when combined with extra.
 