### PR TITLE
License file to be included into metadata dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ project_urls =
     Issue Tracker = https://github.com/pypa/wheel/issues
 keywords = wheel, packaging
 license = MIT
+license_file = LICENSE.txt
 
 [options]
 package_dir=


### PR DESCRIPTION
Grüß Gott! ;-)
Please, add the LICENSE.txt file into metadata dir of your package (e.g. by accepting this pull request).
I understand you probably hate software laws etc., so I will be short.

You are using MIT license. It says also: "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software." But your whole package distributed on PyPI.org does not contain even one. This short change will add the file LICENSE.txt (with text of MIT license) into metadata of your package (= into e.g. .../site-packages/wheel-0.36.2-py3.6.egg-info/LICENSE.txt of your virtualenv). This way you are 100% clear and comply with your chosen license.

Thank you for your time.
Pax et bonum.