### PR TITLE
Test Python 3.10 release candidate

### DIFF
--- a/.github/workflows/codeqa-test.yml
+++ b/.github/workflows/codeqa-test.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-10.15, windows-latest]
-        python-version: [2.7, 3.6, 3.9, pypy2, pypy3]
+        python-version: ["2.7", "3.6", "3.9", "3.10-dev", pypy2, pypy3]
         exclude:
         - os: macos-11.0
           python-version: pypy2

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, py10, pypy, pypy3, flake8
+envlist = py27, py35, py36, py37, py38, py39, py310, pypy, pypy3, flake8
 minversion = 3.3.0
 skip_missing_interpreters = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37, py38, py39, pypy, pypy3, flake8
+envlist = py27, py35, py36, py37, py38, py39, py10, pypy, pypy3, flake8
 minversion = 3.3.0
 skip_missing_interpreters = true
 


### PR DESCRIPTION
Python 3.10.0 final is due for release in October:

* https://www.python.org/dev/peps/pep-0619/

The first release candidate is now out and the Python release team has issued a call to action for community members:

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.10 compatibilities during this phase. As always, report any issues to the Python bug tracker.

https://discuss.python.org/t/python-3-10-0rc1-is-now-available/9982?u=hugovk

So let's also test 3.10 on the CI. The good news is everything passes.

---

I didn't yet add 3.10 to the `classifiers` etc., that can wait until 3.10 is released and officially supported, but could be updated now if you wish.

I also added quotes around version numbers in YAML so it doesn't later interpret `3.10` as 3.1: https://dev.to/hugovk/the-python-3-1-problem-85g