### PR TITLE
ci: fix pypy & use Python 3.10.0

### DIFF
--- a/.github/workflows/codeqa-test.yml
+++ b/.github/workflows/codeqa-test.yml
@@ -21,16 +21,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-10.15, macos-11, windows-latest]
-        python-version: ["2.7", "3.6", "3.9", "3.10-dev", pypy2, pypy3]
+        python-version: ["2.7", "3.6", "3.9", "3.10", "pypy-2.7", "pypy-3.7"]
         exclude:
         - os: macos-11
-          python-version: pypy2
+          python-version: pypy-2.7
         - os: windows-latest
-          python-version: 2.7
+          python-version: "2.7"
         - os: windows-latest
-          python-version: pypy2
+          python-version: pypy-2.7
         - os: windows-latest
-          python-version: pypy3
+          python-version: pypy-3.7
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
See https://github.com/actions/setup-python. PyPy 3.6 is no longer supported, so using 3.7.
