### PR TITLE
style: pre-commit additions, remove <3.7 code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,39 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
-    hooks:
-      - id: check-toml
-      - id: debug-statements
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-      - id: mixed-line-ending
-        args: ["--fix=lf"]
-  - repo: https://github.com/psf/black
-    rev: 21.12b0
-    hooks:
-      - id: black
-        args: [--target-version=py37]
-  -  repo: https://github.com/pycqa/isort
-     rev: 5.10.1
-     hooks:
-     - id: isort
-  -   repo: https://gitlab.com/pycqa/flake8
-      rev: 3.9.2
-      hooks:
-      - id: flake8
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+  - id: check-added-large-files
+  - id: check-case-conflict
+  - id: check-merge-conflict
+  - id: check-symlinks
+  - id: check-toml
+  - id: check-yaml
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+    args: ["--fix=lf"]
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.30.0
+  hooks:
+  - id: pyupgrade
+    args: ["--py37-plus"]
+
+- repo: https://github.com/psf/black
+  rev: 21.12b0
+  hooks:
+  - id: black
+    args: [--target-version=py37]
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+    additional_dependencies: [flake8-bugbear]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,12 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+    args: ["-a", "from __future__ import annotations"]
+
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.30.0
   hooks:
@@ -26,11 +32,6 @@ repos:
   hooks:
   - id: black
     args: [--target-version=py37]
-
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
-  hooks:
-  - id: isort
 
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # wheel documentation build configuration file, created by
 # sphinx-quickstart on Thu Jul 12 00:14:09 2012.
@@ -10,7 +9,8 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-import io
+from __future__ import annotations
+
 import os
 import re
 
@@ -49,7 +49,7 @@ copyright = "2012, Daniel Holth"
 # built documents.
 #
 here = os.path.abspath(os.path.dirname(__file__))
-with io.open(
+with open(
     os.path.join(here, "..", "src", "wheel", "__init__.py"), encoding="utf8"
 ) as version_file:
     match = re.search(r"__version__ = '((\d+\.\d+\.\d+).*)'", version_file.read())

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup()

--- a/src/wheel/__init__.py
+++ b/src/wheel/__init__.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 __version__ = "0.37.1"

--- a/src/wheel/__main__.py
+++ b/src/wheel/__main__.py
@@ -2,6 +2,8 @@
 Wheel command line tool (enable python -m wheel syntax)
 """
 
+from __future__ import annotations
+
 import sys
 
 

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -4,6 +4,8 @@ Create a wheel (.whl) distribution.
 A wheel is a built archive format.
 """
 
+from __future__ import annotations
+
 import distutils
 import os
 import re

--- a/src/wheel/cli/__init__.py
+++ b/src/wheel/cli/__init__.py
@@ -2,6 +2,8 @@
 Wheel command-line utility.
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import sys

--- a/src/wheel/cli/convert.py
+++ b/src/wheel/cli/convert.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os.path
 import re
 import shutil

--- a/src/wheel/macosx_libfile.py
+++ b/src/wheel/macosx_libfile.py
@@ -38,6 +38,8 @@ Important remarks:
   target when the arm64 target is 11.0.
 """
 
+from __future__ import annotations
+
 import ctypes
 import os
 import sys
@@ -421,7 +423,7 @@ def calculate_macosx_platform_tag(archive_root, platform_tag):
     assert len(base_version) == 2
     start_version = base_version
     versions_dict = {}
-    for (dirpath, dirnames, filenames) in os.walk(archive_root):
+    for (dirpath, _dirnames, filenames) in os.walk(archive_root):
         for filename in filenames:
             if filename.endswith(".dylib") or filename.endswith(".so"):
                 lib_path = os.path.join(dirpath, filename)

--- a/src/wheel/metadata.py
+++ b/src/wheel/metadata.py
@@ -7,7 +7,7 @@ import os.path
 import textwrap
 from email.message import Message
 from email.parser import Parser
-from typing import Iterator, Tuple
+from typing import Iterator
 
 from pkg_resources import Requirement, safe_extra, split_sections
 
@@ -41,7 +41,7 @@ def convert_requirements(requirements: list[str]) -> Iterator[str]:
 
 def generate_requirements(
     extras_require: dict[str, list[str]]
-) -> Iterator[Tuple[str, str]]:
+) -> Iterator[tuple[str, str]]:
     """
     Convert requirements from a setup()-style dictionary to
     ('Requires-Dist', 'requirement') and ('Provides-Extra', 'extra') tuples.

--- a/src/wheel/vendored/packaging/_manylinux.py
+++ b/src/wheel/vendored/packaging/_manylinux.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import functools
 import os
@@ -5,7 +7,7 @@ import re
 import struct
 import sys
 import warnings
-from typing import IO, Dict, Iterator, NamedTuple, Optional, Tuple
+from typing import IO, Iterator, NamedTuple
 
 
 # Python does not provide platform information at sufficient granularity to
@@ -36,7 +38,7 @@ class _ELFFileHeader:
         def unpack(fmt: str) -> int:
             try:
                 data = file.read(struct.calcsize(fmt))
-                result: Tuple[int, ...] = struct.unpack(fmt, data)
+                result: tuple[int, ...] = struct.unpack(fmt, data)
             except struct.error:
                 raise _ELFFileHeader._InvalidELFFileHeader()
             return result[0]
@@ -73,7 +75,7 @@ class _ELFFileHeader:
         self.e_shstrndx = unpack(format_h)
 
 
-def _get_elf_header() -> Optional[_ELFFileHeader]:
+def _get_elf_header() -> _ELFFileHeader | None:
     try:
         with open(sys.executable, "rb") as f:
             elf_header = _ELFFileHeader(f)
@@ -124,7 +126,7 @@ def _have_compatible_abi(arch: str) -> bool:
 # For now, guess what the highest minor version might be, assume it will
 # be 50 for testing. Once this actually happens, update the dictionary
 # with the actual value.
-_LAST_GLIBC_MINOR: Dict[int, int] = collections.defaultdict(lambda: 50)
+_LAST_GLIBC_MINOR: dict[int, int] = collections.defaultdict(lambda: 50)
 
 
 class _GLibCVersion(NamedTuple):
@@ -132,7 +134,7 @@ class _GLibCVersion(NamedTuple):
     minor: int
 
 
-def _glibc_version_string_confstr() -> Optional[str]:
+def _glibc_version_string_confstr() -> str | None:
     """
     Primary implementation of glibc_version_string using os.confstr.
     """
@@ -151,7 +153,7 @@ def _glibc_version_string_confstr() -> Optional[str]:
     return version
 
 
-def _glibc_version_string_ctypes() -> Optional[str]:
+def _glibc_version_string_ctypes() -> str | None:
     """
     Fallback implementation of glibc_version_string using ctypes.
     """
@@ -195,12 +197,12 @@ def _glibc_version_string_ctypes() -> Optional[str]:
     return version_str
 
 
-def _glibc_version_string() -> Optional[str]:
+def _glibc_version_string() -> str | None:
     """Returns glibc version string, or None if not using glibc."""
     return _glibc_version_string_confstr() or _glibc_version_string_ctypes()
 
 
-def _parse_glibc_version(version_str: str) -> Tuple[int, int]:
+def _parse_glibc_version(version_str: str) -> tuple[int, int]:
     """Parse glibc version.
 
     We use a regexp instead of str.split because we want to discard any
@@ -220,7 +222,7 @@ def _parse_glibc_version(version_str: str) -> Tuple[int, int]:
 
 
 @functools.lru_cache()
-def _get_glibc_version() -> Tuple[int, int]:
+def _get_glibc_version() -> tuple[int, int]:
     version_str = _glibc_version_string()
     if version_str is None:
         return (-1, -1)

--- a/src/wheel/vendored/packaging/tags.py
+++ b/src/wheel/vendored/packaging/tags.py
@@ -2,23 +2,14 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+from __future__ import annotations
+
 import logging
 import platform
 import sys
 import sysconfig
 from importlib.machinery import EXTENSION_SUFFIXES
-from typing import (
-    Dict,
-    FrozenSet,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Iterable, Iterator, Sequence, Tuple, cast
 
 from . import _manylinux, _musllinux
 
@@ -27,7 +18,7 @@ logger = logging.getLogger(__name__)
 PythonVersion = Sequence[int]
 MacVersion = Tuple[int, int]
 
-INTERPRETER_SHORT_NAMES: Dict[str, str] = {
+INTERPRETER_SHORT_NAMES: dict[str, str] = {
     "python": "py",  # Generic.
     "cpython": "cp",
     "pypy": "pp",
@@ -93,7 +84,7 @@ class Tag:
         return f"<{self} @ {id(self)}>"
 
 
-def parse_tag(tag: str) -> FrozenSet[Tag]:
+def parse_tag(tag: str) -> frozenset[Tag]:
     """
     Parses the provided tag (e.g. `py3-none-any`) into a frozenset of Tag instances.
 
@@ -109,7 +100,7 @@ def parse_tag(tag: str) -> FrozenSet[Tag]:
     return frozenset(tags)
 
 
-def _get_config_var(name: str, warn: bool = False) -> Union[int, str, None]:
+def _get_config_var(name: str, warn: bool = False) -> int | str | None:
     value = sysconfig.get_config_var(name)
     if value is None and warn:
         logger.debug(
@@ -131,7 +122,7 @@ def _abi3_applies(python_version: PythonVersion) -> bool:
     return len(python_version) > 1 and tuple(python_version) >= (3, 2)
 
 
-def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> List[str]:
+def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> list[str]:
     py_version = tuple(py_version)  # To allow for version comparison.
     abis = []
     version = _version_nodot(py_version[:2])
@@ -168,9 +159,9 @@ def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> List[str]:
 
 
 def cpython_tags(
-    python_version: Optional[PythonVersion] = None,
-    abis: Optional[Iterable[str]] = None,
-    platforms: Optional[Iterable[str]] = None,
+    python_version: PythonVersion | None = None,
+    abis: Iterable[str] | None = None,
+    platforms: Iterable[str] | None = None,
     *,
     warn: bool = False,
 ) -> Iterator[Tag]:
@@ -231,9 +222,9 @@ def _generic_abi() -> Iterator[str]:
 
 
 def generic_tags(
-    interpreter: Optional[str] = None,
-    abis: Optional[Iterable[str]] = None,
-    platforms: Optional[Iterable[str]] = None,
+    interpreter: str | None = None,
+    abis: Iterable[str] | None = None,
+    platforms: Iterable[str] | None = None,
     *,
     warn: bool = False,
 ) -> Iterator[Tag]:
@@ -276,9 +267,9 @@ def _py_interpreter_range(py_version: PythonVersion) -> Iterator[str]:
 
 
 def compatible_tags(
-    python_version: Optional[PythonVersion] = None,
-    interpreter: Optional[str] = None,
-    platforms: Optional[Iterable[str]] = None,
+    python_version: PythonVersion | None = None,
+    interpreter: str | None = None,
+    platforms: Iterable[str] | None = None,
 ) -> Iterator[Tag]:
     """
     Yields the sequence of tags that are compatible with a specific version of Python.
@@ -310,7 +301,7 @@ def _mac_arch(arch: str, is_32bit: bool = _32_BIT_INTERPRETER) -> str:
     return "i386"
 
 
-def _mac_binary_formats(version: MacVersion, cpu_arch: str) -> List[str]:
+def _mac_binary_formats(version: MacVersion, cpu_arch: str) -> list[str]:
     formats = [cpu_arch]
     if cpu_arch == "x86_64":
         if version < (10, 4):
@@ -343,7 +334,7 @@ def _mac_binary_formats(version: MacVersion, cpu_arch: str) -> List[str]:
 
 
 def mac_platforms(
-    version: Optional[MacVersion] = None, arch: Optional[str] = None
+    version: MacVersion | None = None, arch: str | None = None
 ) -> Iterator[str]:
     """
     Yields the platform tags for a macOS system.

--- a/src/wheel/wheelfile.py
+++ b/src/wheel/wheelfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import hashlib
 import os.path

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os.path
 import re
 

--- a/tests/cli/test_pack.py
+++ b/tests/cli/test_pack.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from textwrap import dedent
 from zipfile import ZipFile

--- a/tests/cli/test_unpack.py
+++ b/tests/cli/test_unpack.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from wheel.cli.unpack import unpack
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 pytest local configuration plug-in
 """
 
+from __future__ import annotations
+
 import os.path
 import subprocess
 import sys

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os.path
 import shutil
 import stat
@@ -169,7 +171,7 @@ def test_build_from_readonly_tree(dummy_dist, monkeypatch, tmpdir):
     monkeypatch.chdir(basedir)
 
     # Make the tree read-only
-    for root, dirs, files in os.walk(basedir):
+    for root, _dirs, files in os.walk(basedir):
         for fname in files:
             os.chmod(os.path.join(root, fname), stat.S_IREAD)
 

--- a/tests/test_macosx_libfile.py
+++ b/tests/test_macosx_libfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import distutils.util
 import os
 import sys

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from wheel.metadata import pkginfo_to_metadata
 
 

--- a/tests/test_tagopt.py
+++ b/tests/test_tagopt.py
@@ -3,6 +3,8 @@ Tests for the bdist_wheel tag options (--python-tag, --universal, and
 --plat-name)
 """
 
+from __future__ import annotations
+
 import subprocess
 import sys
 
@@ -48,7 +50,7 @@ def temp_pkg(request, tmpdir):
 
 @pytest.mark.parametrize("temp_pkg", [[True, "xxx"]], indirect=["temp_pkg"])
 def test_nocompile_skips(temp_pkg):
-    assert False  # should have skipped with a "Cannot compile" message
+    assert False  # noqa: B011 - should have skipped with a "Cannot compile" message
 
 
 def test_default_tag(temp_pkg):

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from zipfile import ZIP_DEFLATED, ZipFile
 

--- a/tests/testdata/abi3extension.dist/setup.py
+++ b/tests/testdata/abi3extension.dist/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension, setup
 
 setup(

--- a/tests/testdata/commasinfilenames.dist/setup.py
+++ b/tests/testdata/commasinfilenames.dist/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup(

--- a/tests/testdata/complex-dist/complexdist/__init__.py
+++ b/tests/testdata/complex-dist/complexdist/__init__.py
@@ -1,2 +1,5 @@
+from __future__ import annotations
+
+
 def main():
     return

--- a/tests/testdata/complex-dist/setup.py
+++ b/tests/testdata/complex-dist/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup(

--- a/tests/testdata/extension.dist/setup.py
+++ b/tests/testdata/extension.dist/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import Extension, setup
 
 setup(

--- a/tests/testdata/headers.dist/setup.py
+++ b/tests/testdata/headers.dist/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup(

--- a/tests/testdata/simple.dist/setup.py
+++ b/tests/testdata/simple.dist/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup(

--- a/tests/testdata/unicode.dist/setup.py
+++ b/tests/testdata/unicode.dist/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup(


### PR DESCRIPTION
This adds some pre-commit checks, flake8-bugbear, and most importantly, pyupgrade. I've also run isort's `from __future__ import annotations` injection to allow pyupgrade to further clean up annotations. I've also normalized the indentation of the pre-commit yaml file, it was different for each check.
