### PR TITLE
style: a few more checks, and Tox access to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+exclude: ^src/wheel/vendored
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.1.0
@@ -22,7 +24,7 @@ repos:
     args: ["-a", "from __future__ import annotations"]
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.30.0
+  rev: v2.30.1
   hooks:
   - id: pyupgrade
     args: ["--py37-plus"]
@@ -38,3 +40,19 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear]
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.1.0
+  hooks:
+  - id: codespell
+
+- repo: https://github.com/pre-commit/pygrep-hooks
+  rev: v1.9.0
+  hooks:
+  - id: python-check-blanket-noqa
+  - id: python-check-blanket-type-ignore
+  - id: python-no-eval
+  - id: python-use-type-annotations
+  - id: rst-backticks
+  - id: rst-directive-colons
+  - id: rst-inline-touching-normal

--- a/docs/story.rst
+++ b/docs/story.rst
@@ -5,28 +5,28 @@ I was impressed with Tarek’s packaging talk at PyCon 2010, and I
 admire PEP 345 (Metadata for Python Software Packages 1.2) and PEP 376
 (Database of Installed Python Distributions) which standardize a richer
 metadata format and show how distributions should be installed on disk. So
-naturally with all the hubbub about `packaging` in Python 3.3, I decided
+naturally with all the hubbub about ``packaging`` in Python 3.3, I decided
 to try it to reap the benefits of a more standardized and predictable
 Python packaging experience.
 
-I began by converting `cryptacular`, a password hashing package which
-has a simple C extension, to use setup.cfg. I downloaded the Python 3.3
-source, struggled with the difference between setup.py and setup.cfg
-syntax, fixed the `define_macros` feature, stopped using the missing
-`extras` functionality, and several hours later I was able to generate my
-`METADATA` from `setup.cfg`. I rejoiced at my newfound freedom from the
+I began by converting ``cryptacular``, a password hashing package which
+has a simple C extension, to use ``setup.cfg``. I downloaded the Python 3.3
+source, struggled with the difference between ``setup.py`` and ``setup.cfg``
+syntax, fixed the ``define_macros`` feature, stopped using the missing
+``extras`` functionality, and several hours later I was able to generate my
+``METADATA`` from ``setup.cfg``. I rejoiced at my newfound freedom from the
 tyranny of arbitrary code execution during the build and install process.
 
 It was a lot of work. The package is worse off than before, and it can’t
 be built or installed without patching the Python source code itself.
 
 It was about that time that distutils-sig had a discussion about the
-need to include a generated setup.cfg from setup.cfg because setup.cfg
-wasn’t static enough. Wait, what?
+need to include a generated ``setup.cfg`` from ``setup.cfg`` because
+``setup.cfg`` wasn’t static enough. Wait, what?
 
 Of course there is a different way to massively simplify the install
 process. It’s called built or binary packages. You never have to run
-`setup.py` because there is no `setup.py`. There is only METADATA aka
+``setup.py`` because there is no ``setup.py``. There is only METADATA aka
 PKG-INFO. Installation has two steps: ‘build package’; ‘install
 package’, and you can skip the first step, have someone else do it
 for you, do it on another machine, or install the build system from a
@@ -36,12 +36,12 @@ is still complicated, but installation is simple.
 With the binary package strategy people who want to install use a simple,
 compatible installer, and people who want to package use whatever is
 convenient for them for as long as it meets their needs. No one has
-to rewrite `setup.py` for their own or the 20k+ other packages on PyPI
+to rewrite ``setup.py`` for their own or the 20k+ other packages on PyPI
 unless a different build system does a better job.
 
 Wheel is my attempt to benefit from the excellent distutils-sig work
-without having to fix the intractable `distutils` software itself. Like
-METADATA and .dist-info directories but unlike Extension(), it’s
+without having to fix the intractable ``distutils`` software itself. Like
+``METADATA`` and ``.dist-info`` directories but unlike Extension(), it’s
 simple enough that there really could be alternate implementations; the
 simplest (but less than ideal) installer is nothing more than “unzip
 archive.whl” somewhere on sys.path.
@@ -51,11 +51,11 @@ of eggs. Some comparisons:
 
 * Wheel is an installation format; egg is importable. Wheel archives do not need to include .pyc and are less tied to a specific Python version or implementation. Wheel can install (pure Python) packages built with previous versions of Python so you don’t always have to wait for the packager to catch up.
 
-* Wheel uses .dist-info directories; egg uses .egg-info. Wheel is compatible with the new world of Python `packaging` and the new concepts it brings.
+* Wheel uses .dist-info directories; egg uses .egg-info. Wheel is compatible with the new world of Python ``packaging`` and the new concepts it brings.
 
 * Wheel has a richer file naming convention for today’s multi-implementation world. A single wheel archive can indicate its compatibility with a number of Python language versions and implementations, ABIs, and system architectures. Historically the ABI has been specific to a CPython release, but when we get a longer-term ABI, wheel will be ready.
 
-* Wheel is lossless. The first wheel implementation `bdist_wheel` always generates `egg-info`, and then converts it to a `.whl`. Later tools will allow for the conversion of existing eggs and bdist_wininst distributions.
+* Wheel is lossless. The first wheel implementation ``bdist_wheel`` always generates ``egg-info``, and then converts it to a ``.whl``. Later tools will allow for the conversion of existing eggs and bdist_wininst distributions.
 
 * Wheel is versioned. Every wheel file contains the version of the wheel specification and the implementation that packaged it. Hopefully the next migration can simply be to Wheel 2.0.
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,28 +4,18 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, pypy3.7, flake8
+envlist = py37, py38, py39, py310, pypy3.7, lint
 minversion = 3.3.0
 skip_missing_interpreters = true
 
 [testenv]
+depends = lint
 commands = {envpython} -b -m pytest -W always {posargs}
 extras = test
 
-[testenv:black]
+[testenv:lint]
+depends =
 basepython = python3
-deps = black
-commands = black -t py37 src tests
-skip_install = true
-
-[testenv:isort]
-basepython = python3
-deps = isort
-commands = isort src tests
-skip_install = true
-
-[testenv:flake8]
-basepython = python3
-deps = flake8
-commands = flake8 src tests
+deps = pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure
 skip_install = true


### PR DESCRIPTION
I've added a few more checks; the main one that triggered a bit was the RST check, which found some markdown syntax in an RST file.

I've also moved tox over to running pre-commit, for consistency. There's now a `tox -e lint` job, and the old separate jobs were removed. Though you can run individual checks, so if you care about them, I can add them back in.

