### PR TITLE
Remove redundant Python < 3.6 skips

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,7 +4,7 @@ Development
 Pull Requests
 -------------
 
-- Submit Pull Requests against the ``master`` branch.
+- Submit Pull Requests against the ``main`` branch.
 - Provide a good description of what you're doing and why.
 - Provide tests that cover your changes and try to run the tests locally first.
 
@@ -35,13 +35,13 @@ click "New pull request". That's it.
 Automated Testing
 -----------------
 
-All pull requests and merges to 'master' branch are tested in `Github Actions`_
+All pull requests and merges to ``main`` branch are tested in `GitHub Actions`_
 based on the workflows in the ``.github`` directory.
 
 The only way to trigger the test suite to run again for a pull request is to
 submit another change to the pull branch.
 
-.. _Github Actions: https://github.com/actions
+.. _GitHub Actions: https://github.com/actions
 
 Running Tests Locally
 ---------------------

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -63,10 +63,6 @@ def test_no_scripts(wheel_paths):
         assert ".data/scripts/" not in entry.filename
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 6),
-    reason="Packaging unicode file names only works reliably on Python 3.6+",
-)
 def test_unicode_record(wheel_paths):
     path = next(path for path in wheel_paths if "unicode.dist" in path)
     with ZipFile(path) as zf:
@@ -142,9 +138,6 @@ def test_build_number(dummy_dist, monkeypatch, tmpdir):
         assert "dummy_dist-1.0.dist-info/METADATA" in filenames
 
 
-@pytest.mark.skipif(
-    sys.version_info[0] < 3, reason="The limited ABI only works on Python 3+"
-)
 def test_limited_abi(monkeypatch, tmpdir):
     """Test that building a binary wheel with the limited ABI works."""
     this_dir = os.path.dirname(__file__)


### PR DESCRIPTION
And refer to `main` in docs.