### PR TITLE
Recommend build instead of invoking setup.py directly

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-To build a wheel for your setuptools based project::
+To build a wheel for your project::
 
     python -m pip install build
     python -m build --wheel

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,8 @@ Quickstart
 
 To build a wheel for your setuptools based project::
 
-    python setup.py bdist_wheel
+    python -m pip install build
+    python -m build --wheel
 
 The wheel will go to ``dist/yourproject-<tags>.whl``.
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -4,7 +4,7 @@ User Guide
 Building Wheels
 ---------------
 
-Building wheels from a setuptools_ based project is simple::
+To build a wheel for your project::
 
     python -m pip install build
     python -m build --wheel
@@ -21,7 +21,6 @@ adding this to your ``setup.cfg`` file:
     [bdist_wheel]
     universal = 1
 
-.. _setuptools: https://pypi.org/project/setuptools/
 
 Including license files in the generated wheel file
 ---------------------------------------------------

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -6,7 +6,8 @@ Building Wheels
 
 Building wheels from a setuptools_ based project is simple::
 
-    python setup.py bdist_wheel
+    python -m pip install build
+    python -m build --wheel
 
 This will build any C extensions in the project and then package those and the
 pure Python code into a ``.whl`` file in the ``dist`` directory.


### PR DESCRIPTION
Fixes https://github.com/pypa/wheel/issues/424.

Use https://github.com/pypa/build instead of invoking `setup.py` directly.

See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for the long version.

And https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary for the summary.