### PR TITLE
CI: Reconfigure build matrix for Python 3.11 and PyPy 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+        #cache: 'pip'
     - name: Install the project
       run: "pip install --no-binary=:all: ."
     - name: Install test dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-3.8", "pypy-3.9"]
         include:
         - os: macos-latest
@@ -31,7 +31,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-        #cache: 'pip'
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: pip-test-${{ matrix.python-version }}-${{ matrix.os }}
     - name: Install the project
       run: "pip install --no-binary=:all: ."
     - name: Install test dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-3.8", "pypy-3.9"]
         include:
         - os: macos-latest
+          python-version: "3.7"
+        - os: windows-latest
+          python-version: "3.7"
+        - os: macos-latest
           python-version: "3.10"
         - os: windows-latest
           python-version: "3.10"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,44 +4,34 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15, macos-11, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
-        exclude:
-        - os: macos-10.15
-          python-version: "3.8"
-        - os: macos-10.15
-          python-version: "3.9"
-        - os: macos-10.15
-          python-version: "pypy-3.7"
-        - os: macos-11
-          python-version: "3.8"
-        - os: macos-11
-          python-version: "3.9"
-        - os: macos-11
-          python-version: "pypy-3.7"
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-3.8", "pypy-3.9"]
+        include:
+        - os: macos-latest
+          python-version: "3.10"
         - os: windows-latest
-          python-version: "3.8"
+          python-version: "3.10"
+        - os: macos-latest
+          python-version: "pypy-3.9"
         - os: windows-latest
-          python-version: "3.9"
-        - os: windows-latest
-          python-version: "pypy-3.7"
+          python-version: "pypy-3.9"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: pip-test-${{ matrix.python-version }}-${{ matrix.os }}
+        cache: 'pip'
     - name: Install the project
       run: "pip install --no-binary=:all: ."
     - name: Install test dependencies


### PR DESCRIPTION
Reconfigures the build matrix to include Python 3.11 (which is currently in beta) and PyPy 3.9. PyPy 3.8 is also added and 3.7 is removed.

All Python versions (3.7 to 3.11, and PyPy 3.8 and 3.9) are tested on Ubuntu, and the latest stable versions (currently Python 3.10 and PyPy 3.9) also on macOS and Windows.

A weekly scheduled run is also added to catch changes in dependencies and environments (each Monday at 06:00 UTC), and `workflow_dispatch` is added to be able to manually trigger the CI workflow.

The used actions are updated to v3 and caching is now configured in the setup-python action.