### PR TITLE
Add support for `license_files` specified in `setup.py`

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -6,6 +6,9 @@ Release Notes
 - Dropped support for Python < 3.7
 - Updated vendored ``packaging`` to 21.3
 - Replaced all uses of ``distutils`` with ``setuptools``
+- The handling of ``license_files`` (including glob patterns and default
+  values) is now delegated to ``setuptools>=57.0.0`` (#466).
+  The package dependencies were updated to reflect this change.
 
 **0.37.1 (2021-12-22)**
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ package_dir=
     = src
 packages = find:
 python_requires = >=3.7
-install_requires = setuptools >= 45.2.0
+install_requires = setuptools >= 57.0.0
 zip_safe = False
 
 [options.packages.find]

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -432,14 +432,6 @@ class bdist_wheel(Command):
     @property
     def license_paths(self):
         metadata = self.distribution.metadata
-
-        if metadata.license_file:
-            warnings.warn(
-                'The "license_file" option is deprecated. Use '
-                '"license_files" instead.',
-                DeprecationWarning,
-            )
-
         return sorted(metadata.license_files or [])
 
     def egg2dist(self, egginfo_path, distinfo_path):

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -118,7 +118,7 @@ def remove_readonly(func, path, excinfo):
 
 def _split_list(value, separator=","):
     """Mimic parsing of a list configuration in setuptools"""
-    values = value.splitlines() if '\n' in value else value.split(separator)
+    values = value.splitlines() if "\n" in value else value.split(separator)
     return (item.strip() for item in values)
 
 
@@ -135,9 +135,7 @@ def _expand(patterns):
                 continue
 
             if path not in files and os.path.isfile(path):
-                log.info(
-                    f'adding license file "{path}" (matched pattern "{pattern}")'
-                )
+                log.info(f'adding license file "{path}" (matched pattern "{pattern}")')
                 files.add(path)
 
     return files
@@ -465,7 +463,7 @@ class bdist_wheel(Command):
 
         license_file = (
             getattr(metadata, "license_file", None)
-            or raw_metadata.get("license_file", ['', None])[-1]
+            or raw_metadata.get("license_file", ["", None])[-1]
         )
 
         if license_file:

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -432,7 +432,6 @@ class bdist_wheel(Command):
     @property
     def license_paths(self):
         metadata = self.distribution.metadata
-        files = set()
 
         if metadata.license_file:
             warnings.warn(
@@ -440,10 +439,8 @@ class bdist_wheel(Command):
                 '"license_files" instead.',
                 DeprecationWarning,
             )
-            files.add(metadata.license_file)
 
-        license_files = metadata.license_files or []
-        return sorted({*files, *license_files})
+        return sorted(metadata.license_files or [])
 
     def egg2dist(self, egginfo_path, distinfo_path):
         """Convert an .egg-info directory into a .dist-info directory"""

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -15,7 +15,6 @@ import sysconfig
 import warnings
 from collections import OrderedDict
 from email.generator import BytesGenerator, Generator
-from glob import iglob
 from io import BytesIO
 from shutil import rmtree
 from sysconfig import get_config_var
@@ -23,7 +22,6 @@ from zipfile import ZIP_DEFLATED, ZIP_STORED
 
 import pkg_resources
 from setuptools import Command
-from setuptools import __version__ as setuptools_version
 
 from . import __version__ as wheel_version
 from .macosx_libfile import calculate_macosx_platform_tag

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -434,16 +434,15 @@ class bdist_wheel(Command):
         metadata = self.distribution.metadata
         files = set()
 
-        license_file = getattr(metadata, "license_file", None)
-        if license_file:
+        if metadata.license_file:
             warnings.warn(
                 'The "license_file" option is deprecated. Use '
                 '"license_files" instead.',
                 DeprecationWarning,
             )
-            files.add(license_file)
+            files.add(metadata.license_file)
 
-        license_files = getattr(metadata, "license_files", None) or []
+        license_files = metadata.license_files or []
         return sorted({*files, *license_files})
 
     def egg2dist(self, egginfo_path, distinfo_path):

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -116,6 +116,12 @@ def remove_readonly(func, path, excinfo):
     func(path)
 
 
+def _split_list(value, separator=","):
+    """Mimic parsing of a list configuration in setuptools"""
+    values = value.splitlines() if '\n' in value else value.split(separator)
+    return (item.strip() for item in values)
+
+
 class bdist_wheel(Command):
 
     description = "create a wheel distribution"
@@ -434,9 +440,8 @@ class bdist_wheel(Command):
     def license_paths(self):
         metadata = self.distribution.get_option_dict("metadata")
         files = set()
-        patterns = sorted(
-            {option for option in metadata.get("license_files", ("", ""))[1].split()}
-        )
+        pattern_values = _split_list(metadata.get("license_files", ("", ""))[1])
+        patterns = sorted(set(pattern_values))
 
         if "license_file" in metadata:
             warnings.warn(

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -44,6 +44,11 @@ setup(
 )
 """
 
+lincense_files_in_old_setuptools = pytest.mark.xfail(
+    tuple(setuptools_version.split(".")) < ("57", "0"),
+    reason="Old versions of setuptools don't get license_files quite right",
+)
+
 
 @pytest.fixture
 def dummy_dist(tmpdir_factory):
@@ -71,10 +76,7 @@ def test_unicode_record(wheel_paths):
     assert "åäö_日本語.py".encode() in record
 
 
-@pytest.mark.xfail(
-    tuple(setuptools_version.split(".")) < ("57", "0"),
-    reason="Old versions of setuptools don't get license_files quite right",
-)
+@lincense_files_in_old_setuptools
 def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
@@ -101,8 +103,16 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
 @pytest.mark.parametrize(
     "config_file, config",
     [
-        ("setup.cfg", "[metadata]\nlicense_files=licenses/*\n  LICENSE"),
-        ("setup.cfg", "[metadata]\nlicense_files=licenses/*, LICENSE"),
+        pytest.param(
+            "setup.cfg",
+            "[metadata]\nlicense_files=licenses/*\n  LICENSE",
+            marks=lincense_files_in_old_setuptools,
+        ),
+        pytest.param(
+            "setup.cfg",
+            "[metadata]\nlicense_files=licenses/*, LICENSE",
+            marks=lincense_files_in_old_setuptools,
+        ),
         (
             "setup.py",
             SETUPPY_EXAMPLE.replace(

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -8,7 +8,6 @@ import sys
 from zipfile import ZipFile
 
 import pytest
-from setuptools import __version__ as setuptools_version
 
 from wheel.bdist_wheel import bdist_wheel
 from wheel.wheelfile import WheelFile
@@ -45,13 +44,6 @@ setup(
 """
 
 
-def license_files_in_old_setuptools(old_version):
-    return pytest.mark.xfail(
-        tuple(setuptools_version.split(".")) < tuple(old_version.split(".")),
-        reason=f"setuptools < {old_version} has problems with license_files",
-    )
-
-
 @pytest.fixture
 def dummy_dist(tmpdir_factory):
     basedir = tmpdir_factory.mktemp("dummy_dist")
@@ -78,7 +70,6 @@ def test_unicode_record(wheel_paths):
     assert "åäö_日本語.py".encode() in record
 
 
-@license_files_in_old_setuptools("57.0")
 def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
@@ -91,7 +82,6 @@ def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
-@license_files_in_old_setuptools("56.0")
 def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
     dummy_dist.join("setup.cfg").write("[metadata]\nlicense_file=licenses/DUMMYFILE")
     monkeypatch.chdir(dummy_dist)
@@ -106,16 +96,8 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
 @pytest.mark.parametrize(
     "config_file, config",
     [
-        pytest.param(
-            "setup.cfg",
-            "[metadata]\nlicense_files=licenses/*\n  LICENSE",
-            marks=license_files_in_old_setuptools("57.0"),
-        ),
-        pytest.param(
-            "setup.cfg",
-            "[metadata]\nlicense_files=licenses/*, LICENSE",
-            marks=license_files_in_old_setuptools("57.0"),
-        ),
+        ("setup.cfg", "[metadata]\nlicense_files=licenses/*\n  LICENSE"),
+        ("setup.cfg", "[metadata]\nlicense_files=licenses/*, LICENSE"),
         (
             "setup.py",
             SETUPPY_EXAMPLE.replace(

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -82,20 +82,6 @@ def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
-def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
-    dummy_dist.join("setup.cfg").write("[metadata]\nlicense_file=licenses/DUMMYFILE")
-    monkeypatch.chdir(dummy_dist)
-    prog = [sys.executable, "-W", "default"]
-    build_log = subprocess.check_output(
-        [*prog, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"],
-        stderr=subprocess.STDOUT,
-    )
-    assert b"license_file parameter is deprecated" in build_log
-    with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
-        license_files = {"dummy_dist-1.0.dist-info/DUMMYFILE"}
-        assert set(wf.namelist()) == DEFAULT_FILES | license_files
-
-
 @pytest.mark.parametrize(
     "config_file, config",
     [

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -117,22 +117,6 @@ def test_licenses_override(dummy_dist, monkeypatch, tmpdir, config_file, config)
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
-def test_licenses_distutils(dummy_dist, monkeypatch, tmpdir):
-    dummy_dist.join("setup.py").write(
-        SETUPPY_EXAMPLE.replace("setuptools", "distutils.core")
-    )
-    dummy_dist.join("setup.cfg").write("[metadata]\nlicense_files=licenses/*, LICENSE")
-    monkeypatch.chdir(dummy_dist)
-    subprocess.check_call(
-        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"]
-    )
-    with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
-        license_files = {
-            "dummy_dist-1.0.dist-info/" + fname for fname in {"DUMMYFILE", "LICENSE"}
-        }
-        assert set(wf.namelist()) == DEFAULT_FILES | license_files
-
-
 def test_licenses_disabled(dummy_dist, monkeypatch, tmpdir):
     dummy_dist.join("setup.cfg").write("[metadata]\nlicense_files=\n")
     monkeypatch.chdir(dummy_dist)

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -8,10 +8,10 @@ import sys
 from zipfile import ZipFile
 
 import pytest
+from setuptools import __version__ as setuptools_version
 
 from wheel.bdist_wheel import bdist_wheel
 from wheel.wheelfile import WheelFile
-from setuptools import __version__ as setuptools_version
 
 DEFAULT_FILES = {
     "dummy_dist-1.0.dist-info/top_level.txt",

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -90,7 +90,7 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
         [*prog, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"],
         stderr=subprocess.STDOUT,
     )
-    assert b'"license_file" option is deprecated' in build_log
+    assert b"license_file parameter is deprecated" in build_log
     with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
         license_files = {"dummy_dist-1.0.dist-info/DUMMYFILE"}
         assert set(wf.namelist()) == DEFAULT_FILES | license_files

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -11,6 +11,7 @@ import pytest
 
 from wheel.bdist_wheel import bdist_wheel
 from wheel.wheelfile import WheelFile
+from setuptools import __version__ as setuptools_version
 
 DEFAULT_FILES = {
     "dummy_dist-1.0.dist-info/top_level.txt",
@@ -70,6 +71,10 @@ def test_unicode_record(wheel_paths):
     assert "åäö_日本語.py".encode() in record
 
 
+@pytest.mark.xfail(
+    tuple(setuptools_version.split(".")) < ("57", "0"),
+    reason="Old versions of setuptools don't get license_files quite right",
+)
 def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -94,9 +94,10 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
-def test_licenses_override(dummy_dist, monkeypatch, tmpdir):
+@pytest.mark.parametrize("patterns", ["licenses/*\n  LICENSE", "licenses/*, LICENSE"])
+def test_licenses_override(dummy_dist, monkeypatch, tmpdir, patterns):
     dummy_dist.join("setup.cfg").write(
-        "[metadata]\nlicense_files=licenses/*\n  LICENSE"
+        "[metadata]\nlicense_files=" + patterns
     )
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -117,6 +117,22 @@ def test_licenses_override(dummy_dist, monkeypatch, tmpdir, config_file, config)
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
+def test_licenses_distutils(dummy_dist, monkeypatch, tmpdir):
+    dummy_dist.join("setup.py").write(
+        SETUPPY_EXAMPLE.replace("setuptools", "distutils.core")
+    )
+    dummy_dist.join("setup.cfg").write("[metadata]\nlicense_files=licenses/*, LICENSE")
+    monkeypatch.chdir(dummy_dist)
+    subprocess.check_call(
+        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"]
+    )
+    with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
+        license_files = {
+            "dummy_dist-1.0.dist-info/" + fname for fname in {"DUMMYFILE", "LICENSE"}
+        }
+        assert set(wf.namelist()) == DEFAULT_FILES | license_files
+
+
 def test_licenses_disabled(dummy_dist, monkeypatch, tmpdir):
     dummy_dist.join("setup.cfg").write("[metadata]\nlicense_files=\n")
     monkeypatch.chdir(dummy_dist)

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -43,6 +43,7 @@ setup(
 )
 """
 
+
 @pytest.fixture
 def dummy_dist(tmpdir_factory):
     basedir = tmpdir_factory.mktemp("dummy_dist")
@@ -99,9 +100,9 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
         ("setup.cfg", "[metadata]\nlicense_files=licenses/*, LICENSE"),
         (
             "setup.py",
-            SETUPPY_EXAMPLE.replace(")", "  license_files=['licenses/*', 'LICENSE'])")
+            SETUPPY_EXAMPLE.replace(")", "  license_files=['licenses/*', 'LICENSE'])"),
         ),
-    ]
+    ],
 )
 def test_licenses_override(dummy_dist, monkeypatch, tmpdir, config_file, config):
     dummy_dist.join(config_file).write(config)

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -45,7 +45,7 @@ setup(
 """
 
 
-def lincense_files_in_old_setuptools(old_version):
+def license_files_in_old_setuptools(old_version):
     return pytest.mark.xfail(
         tuple(setuptools_version.split(".")) < tuple(old_version.split(".")),
         reason=f"setuptools < {old_version} has problems with license_files",
@@ -78,7 +78,7 @@ def test_unicode_record(wheel_paths):
     assert "åäö_日本語.py".encode() in record
 
 
-@lincense_files_in_old_setuptools("57.0")
+@license_files_in_old_setuptools("57.0")
 def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
@@ -91,7 +91,7 @@ def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
-@lincense_files_in_old_setuptools("56.0")
+@license_files_in_old_setuptools("56.0")
 def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
     dummy_dist.join("setup.cfg").write("[metadata]\nlicense_file=licenses/DUMMYFILE")
     monkeypatch.chdir(dummy_dist)
@@ -109,12 +109,12 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
         pytest.param(
             "setup.cfg",
             "[metadata]\nlicense_files=licenses/*\n  LICENSE",
-            marks=lincense_files_in_old_setuptools("57.0"),
+            marks=license_files_in_old_setuptools("57.0"),
         ),
         pytest.param(
             "setup.cfg",
             "[metadata]\nlicense_files=licenses/*, LICENSE",
-            marks=lincense_files_in_old_setuptools("57.0"),
+            marks=license_files_in_old_setuptools("57.0"),
         ),
         (
             "setup.py",

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -44,10 +44,12 @@ setup(
 )
 """
 
-lincense_files_in_old_setuptools = pytest.mark.xfail(
-    tuple(setuptools_version.split(".")) < ("57", "0"),
-    reason="Old versions of setuptools don't get license_files quite right",
-)
+
+def lincense_files_in_old_setuptools(old_version):
+    return pytest.mark.xfail(
+        tuple(setuptools_version.split(".")) < tuple(old_version.split(".")),
+        reason=f"setuptools < {old_version} has problems with license_files",
+    )
 
 
 @pytest.fixture
@@ -76,7 +78,7 @@ def test_unicode_record(wheel_paths):
     assert "åäö_日本語.py".encode() in record
 
 
-@lincense_files_in_old_setuptools
+@lincense_files_in_old_setuptools("57.0")
 def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
@@ -89,6 +91,7 @@ def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
+@lincense_files_in_old_setuptools("56.0")
 def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
     dummy_dist.join("setup.cfg").write("[metadata]\nlicense_file=licenses/DUMMYFILE")
     monkeypatch.chdir(dummy_dist)
@@ -106,12 +109,12 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
         pytest.param(
             "setup.cfg",
             "[metadata]\nlicense_files=licenses/*\n  LICENSE",
-            marks=lincense_files_in_old_setuptools,
+            marks=lincense_files_in_old_setuptools("57.0"),
         ),
         pytest.param(
             "setup.cfg",
             "[metadata]\nlicense_files=licenses/*, LICENSE",
-            marks=lincense_files_in_old_setuptools,
+            marks=lincense_files_in_old_setuptools("57.0"),
         ),
         (
             "setup.py",

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -85,9 +85,12 @@ def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
 def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
     dummy_dist.join("setup.cfg").write("[metadata]\nlicense_file=licenses/DUMMYFILE")
     monkeypatch.chdir(dummy_dist)
-    subprocess.check_call(
-        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"]
+    prog = [sys.executable, "-W", "default"]
+    build_log = subprocess.check_output(
+        [*prog, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"],
+        stderr=subprocess.STDOUT,
     )
+    assert b'"license_file" option is deprecated' in build_log
     with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
         license_files = {"dummy_dist-1.0.dist-info/DUMMYFILE"}
         assert set(wf.namelist()) == DEFAULT_FILES | license_files

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -100,7 +100,9 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
         ("setup.cfg", "[metadata]\nlicense_files=licenses/*, LICENSE"),
         (
             "setup.py",
-            SETUPPY_EXAMPLE.replace(")", "  license_files=['licenses/*', 'LICENSE'])"),
+            SETUPPY_EXAMPLE.replace(
+                ")", "  license_files=['licenses/DUMMYFILE', 'LICENSE'])"
+            ),
         ),
     ],
 )


### PR DESCRIPTION
As discussed in #465, `bdist_wheel` will behave differently when `license_files` is specified in `setup.py` or in `setup.cfg`.

The main idea of this PR is to make the behaviour consistent across these different possibilities.

I am supposing that the original intention of the `wheel` authors was to also support distributions using `from distutils.core import setup` in addition to `from setuptools import setup`.
In my mind this justifies the choice for `distribution.get_option_dict("metadata")` instead of simply looking up in `distribution.metadata`.
Therefore, I am attempting to preserve this backward compatibility in the PR.

If this is not required the implementation. can be further simplified.

Closes #444.
Closes #465.