### PR TITLE
Add configuration for Flake8.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,9 @@ skip_gitignore = true
 
 [flake8]
 max-line-length = 88
+select = B,B9,E,F,C9
+extend-ignore = E203
+extend-exclude = vendored
 
 [tool:pytest]
 testpaths = tests


### PR DESCRIPTION
The main differences from the defaults are enabling the opinionated bugbear codes and excluding the vendored sources.