### PR TITLE
fix PyPy SOABI parsing

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -13,6 +13,8 @@ Release Notes
 - Fixed ``ValueError: ZIP does not support timestamps before 1980`` when using
   ``SOURCE_DATE_EPOCH=0`` or when on-disk timestamps are earlier than 1980-01-01. Such
   timestamps are now changed to the minimum value before packaging.
+- The future-proof fix in 0.36.0 for converting PyPy's SOABI into a abi tag was
+  faulty. Fixed so that future changes in the SOABI will not change the tag.
 
 **0.37.1 (2021-12-22)**
 

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -69,7 +69,7 @@ def get_flag(var, fallback, expected=True, warn=True):
 
 
 def get_abi_tag():
-    """Return the ABI tag based on SOABI (if available) or emulate SOABI (PyPy)."""
+    """Return the ABI tag based on SOABI (if available) or emulate SOABI (PyPy2)."""
     soabi = get_config_var("SOABI")
     impl = tags.interpreter_name()
     if not soabi and impl in ("cp", "pp") and hasattr(sys, "maxunicode"):
@@ -87,9 +87,9 @@ def get_abi_tag():
             m = "m"
 
         abi = f"{impl}{tags.interpreter_version()}{d}{m}{u}"
-    elif soabi and soabi.startswith("cpython-"):
+    elif soabi and impl == 'cp':
         abi = "cp" + soabi.split("-")[1]
-    elif soabi and soabi.startswith("pypy-"):
+    elif soabi and impl == 'pp':
         # we want something like pypy36-pp73
         abi = "-".join(soabi.split("-")[:2])
         abi = abi.replace(".", "_").replace("-", "_")

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -87,9 +87,9 @@ def get_abi_tag():
             m = "m"
 
         abi = f"{impl}{tags.interpreter_version()}{d}{m}{u}"
-    elif soabi and impl == 'cp':
+    elif soabi and impl == "cp":
         abi = "cp" + soabi.split("-")[1]
-    elif soabi and impl == 'pp':
+    elif soabi and impl == "pp":
         # we want something like pypy36-pp73
         abi = "-".join(soabi.split("-")[:2])
         abi = abi.replace(".", "_").replace("-", "_")

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -17,7 +17,6 @@ from collections import OrderedDict
 from email.generator import BytesGenerator, Generator
 from io import BytesIO
 from shutil import rmtree
-from sysconfig import get_config_var
 from zipfile import ZIP_DEFLATED, ZIP_STORED
 
 import pkg_resources
@@ -55,7 +54,7 @@ def get_platform(archive_root):
 def get_flag(var, fallback, expected=True, warn=True):
     """Use a fallback value for determining SOABI flags if the needed config
     var is unset or unavailable."""
-    val = get_config_var(var)
+    val = sysconfig.get_config_var(var)
     if val is None:
         if warn:
             warnings.warn(
@@ -70,7 +69,7 @@ def get_flag(var, fallback, expected=True, warn=True):
 
 def get_abi_tag():
     """Return the ABI tag based on SOABI (if available) or emulate SOABI (PyPy2)."""
-    soabi = get_config_var("SOABI")
+    soabi = sysconfig.get_config_var("SOABI")
     impl = tags.interpreter_name()
     if not soabi and impl in ("cp", "pp") and hasattr(sys, "maxunicode"):
         d = ""

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -5,11 +5,13 @@ import shutil
 import stat
 import subprocess
 import sys
+import sysconfig
+from wheel.vendored.packaging import tags
 from zipfile import ZipFile
 
 import pytest
 
-from wheel.bdist_wheel import bdist_wheel
+from wheel.bdist_wheel import bdist_wheel, get_abi_tag
 from wheel.wheelfile import WheelFile
 
 DEFAULT_FILES = {
@@ -218,3 +220,22 @@ def test_unix_epoch_timestamps(dummy_dist, monkeypatch, tmpdir):
             "--build-number=2",
         ]
     )
+
+def test_get_abi_tag_old(monkeypatch):
+    monkeypatch.setattr(
+        tags, "interpreter_name", lambda: "pp"
+    )
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda x: "pypy36-pp73"
+    )
+    assert get_abi_tag() == "pypy36_pp73"
+
+def test_get_abi_tag_new(monkeypatch):
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda x: "pypy37-pp73-darwin"
+    )
+    monkeypatch.setattr(
+        tags, "interpreter_name", lambda: "pp"
+    )
+    assert get_abi_tag() == "pypy37_pp73"
+

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -6,12 +6,12 @@ import stat
 import subprocess
 import sys
 import sysconfig
-from wheel.vendored.packaging import tags
 from zipfile import ZipFile
 
 import pytest
 
 from wheel.bdist_wheel import bdist_wheel, get_abi_tag
+from wheel.vendored.packaging import tags
 from wheel.wheelfile import WheelFile
 
 DEFAULT_FILES = {
@@ -221,21 +221,14 @@ def test_unix_epoch_timestamps(dummy_dist, monkeypatch, tmpdir):
         ]
     )
 
+
 def test_get_abi_tag_old(monkeypatch):
-    monkeypatch.setattr(
-        tags, "interpreter_name", lambda: "pp"
-    )
-    monkeypatch.setattr(
-        sysconfig, "get_config_var", lambda x: "pypy36-pp73"
-    )
+    monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "pypy36-pp73")
     assert get_abi_tag() == "pypy36_pp73"
 
-def test_get_abi_tag_new(monkeypatch):
-    monkeypatch.setattr(
-        sysconfig, "get_config_var", lambda x: "pypy37-pp73-darwin"
-    )
-    monkeypatch.setattr(
-        tags, "interpreter_name", lambda: "pp"
-    )
-    assert get_abi_tag() == "pypy37_pp73"
 
+def test_get_abi_tag_new(monkeypatch):
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "pypy37-pp73-darwin")
+    monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
+    assert get_abi_tag() == "pypy37_pp73"


### PR DESCRIPTION
In #373 I started fixing the SOABI parsing to trim off the platform tag from the ABI tag. I used the wrong logic: the `soabi.startswith("pypy-")`  would not be True. This means the code on line 96 was used for PyPy. No harm was done, but if PyPy updates its SOABI tag to fix [this issue](https://foss.heptapod.net/pypy/pypy/-/issues/3816), the fix here will be needed.

Edit: to be clear: the SOABI is currently `pypy36-pp73`, which does not start with `pypy-`