### PR TITLE
Allow `METADATA` file to contain UTF-8 chars

### DIFF
--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -15,6 +15,7 @@ import sysconfig
 import warnings
 from collections import OrderedDict
 from email.generator import BytesGenerator, Generator
+from email.policy import EmailPolicy
 from glob import iglob
 from io import BytesIO
 from shutil import rmtree
@@ -534,8 +535,13 @@ class bdist_wheel(Command):
                 adios(dependency_links_path)
 
         pkg_info_path = os.path.join(distinfo_path, "METADATA")
+        serialization_policy = EmailPolicy(
+            utf8=True,
+            mangle_from_=False,
+            max_line_length=0,
+        )
         with open(pkg_info_path, "w", encoding="utf-8") as out:
-            Generator(out, mangle_from_=False, maxheaderlen=0).flatten(pkg_info)
+            Generator(out, policy=serialization_policy).flatten(pkg_info)
 
         for license_path in self.license_paths:
             filename = os.path.basename(license_path)

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -76,7 +76,7 @@ UTF8_PKG_INFO = """\
 Metadata-Version: 2.1
 Name: helloworld
 Version: 42
-Author-email: John X. Ãørçeč" <john@utf8.org>, Γαμα קּ 東 <gama@utf8.org>
+Author-email: "John X. Ãørçeč" <john@utf8.org>, Γαμα קּ 東 <gama@utf8.org>
 
 
 UTF-8 描述 説明
@@ -106,7 +106,7 @@ def test_preserve_unicode_metadata(monkeypatch, tmp_path):
     cmd_obj.egg2dist(egginfo, distinfo)
 
     metadata = (distinfo / "METADATA").read_text(encoding="utf-8")
-    assert "John X. Ãørçeč" in metadata
+    assert 'Author-email: "John X. Ãørçeč"' in metadata
     assert "Γαμα קּ 東 " in metadata
     assert "UTF-8 描述 説明" in metadata
 


### PR DESCRIPTION
`setuptools` produces UTF-8 `PKG-INFO` files. However, after processed by `wheel`, some serialization problems show up in the `METADATA` file (see https://github.com/pypa/setuptools/issues/3663#issuecomment-1308717064)

This PR attempts to allow UTF-8 in `METADATA`[^1] produced by wheel.

Closes #488.

[^1]: Initially, I was not 100% sure if the issue was related to standardization. PyPA specs do mention a bunch of old RFCs, but they are also clear state that ["strings must be serialised using the UTF-8 encoding"](https://packaging.python.org/en/latest/specifications/core-metadata/). Flit adopts the UTF-8 approach.