### PR TITLE
Replace spaces in platform names with underscores

### DIFF
--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -285,7 +285,9 @@ class bdist_wheel(Command):
             ):
                 plat_name = "linux_i686"
 
-        plat_name = plat_name.lower().replace("-", "_").replace(".", "_")
+        plat_name = (
+            plat_name.lower().replace("-", "_").replace(".", "_").replace(" ", "_")
+        )
 
         if self.root_is_pure:
             if self.universal:

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -282,3 +282,11 @@ def test_get_abi_tag_new(monkeypatch):
     monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "pypy37-pp73-darwin")
     monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
     assert get_abi_tag() == "pypy37_pp73"
+
+
+def test_platform_with_space(dummy_dist, monkeypatch):
+    """Ensure building on platforms with a space in the name succeed."""
+    monkeypatch.chdir(dummy_dist)
+    subprocess.check_call(
+        [sys.executable, "setup.py", "bdist_wheel", "--plat-name", "isilon onefs"]
+    )


### PR DESCRIPTION
Without this, wheels produced on such platforms will cause a `WheelError`.

For example: https://gist.github.com/tucked/871d4ec2364379249bf524cf3a42f308