### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/reference/wheel_unpack.rst
+++ b/docs/reference/wheel_unpack.rst
@@ -22,7 +22,7 @@ error if it encounters a mismatch.
 Options
 -------
 
-.. option:: -d, --dest-dir <dir>
+.. option:: -d, --dest <dir>
 
     Directory to unpack the wheel into.
 


### PR DESCRIPTION
The long Argument for unpack is `--dest` and not `--dest-dir`