### PR TITLE
chore: fix pre-commit job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
     args: ["-a", "from __future__ import annotations"]


### PR DESCRIPTION
Quick fix for broken pre-commit (due to poetry-core 1.5.0 breaking isort, see https://github.com/PyCQA/isort/pull/2078) ~~and flake8 reporting W503 (incompatible with Black & skipped by default)~~ (seems to already have been fixed via a push directly to main).
