### PR TITLE
tests: use modern tmp_path instead of py.path based tmpdir

### DIFF
--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -17,9 +17,9 @@ def test_egg_re():
                 assert egg_info_re.match(line), line
 
 
-def test_convert_egg(egg_paths, tmpdir):
-    convert(egg_paths, str(tmpdir), verbose=False)
-    wheel_names = [path.basename for path in tmpdir.listdir()]
+def test_convert_egg(egg_paths, tmp_path):
+    convert(egg_paths, str(tmp_path), verbose=False)
+    wheel_names = [path.name for path in tmp_path.iterdir()]
     assert len(wheel_names) == len(egg_paths)
     assert all(WHEEL_INFO_RE.match(filename) for filename in wheel_names)
     assert all(

--- a/tests/cli/test_pack.py
+++ b/tests/cli/test_pack.py
@@ -24,8 +24,8 @@ TESTWHEEL_PATH = os.path.join(THISDIR, "..", "testdata", TESTWHEEL_NAME)
     ],
     ids=["nobuildnum", "newbuildarg", "oldbuildnum", "erasebuildnum"],
 )
-def test_pack(tmpdir_factory, tmpdir, build_tag_arg, existing_build_tag, filename):
-    unpack_dir = tmpdir_factory.mktemp("wheeldir")
+def test_pack(tmp_path_factory, tmp_path, build_tag_arg, existing_build_tag, filename):
+    unpack_dir = tmp_path_factory.mktemp("wheeldir")
     with ZipFile(TESTWHEEL_PATH) as zf:
         old_record = zf.read("test-1.0.dist-info/RECORD")
         old_record_lines = sorted(
@@ -37,15 +37,15 @@ def test_pack(tmpdir_factory, tmpdir, build_tag_arg, existing_build_tag, filenam
 
     if existing_build_tag:
         # Add the build number to WHEEL
-        wheel_file_path = unpack_dir.join("test-1.0.dist-info").join("WHEEL")
-        wheel_file_content = wheel_file_path.read_binary()
+        wheel_file_path = unpack_dir.joinpath("test-1.0.dist-info").joinpath("WHEEL")
+        wheel_file_content = wheel_file_path.read_bytes()
         assert b"Build" not in wheel_file_content
         wheel_file_content += b"Build: 3\r\n"
-        wheel_file_path.write_binary(wheel_file_content)
+        wheel_file_path.write_bytes(wheel_file_content)
 
-    pack(str(unpack_dir), str(tmpdir), build_tag_arg)
-    new_wheel_path = tmpdir.join(filename)
-    assert new_wheel_path.isfile()
+    pack(str(unpack_dir), str(tmp_path), build_tag_arg)
+    new_wheel_path = tmp_path.joinpath(filename)
+    assert new_wheel_path.is_file()
 
     with ZipFile(str(new_wheel_path)) as zf:
         new_record = zf.read("test-1.0.dist-info/RECORD")

--- a/tests/cli/test_unpack.py
+++ b/tests/cli/test_unpack.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from wheel.cli.unpack import unpack
 
 
-def test_unpack(wheel_paths, tmpdir):
+def test_unpack(wheel_paths, tmp_path):
     """
     Make sure 'wheel unpack' works.
     This also verifies the integrity of our testing wheel files.
     """
     for wheel_path in wheel_paths:
-        unpack(wheel_path, str(tmpdir))
+        unpack(wheel_path, str(tmp_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 
 
 @pytest.fixture(scope="session")
-def wheels_and_eggs(tmpdir_factory):
+def wheels_and_eggs(tmp_path_factory):
     """Build wheels and eggs from test distributions."""
     test_distributions = (
         "complex-dist",
@@ -28,8 +28,8 @@ def wheels_and_eggs(tmpdir_factory):
 
     pwd = os.path.abspath(os.curdir)
     this_dir = os.path.dirname(__file__)
-    build_dir = tmpdir_factory.mktemp("build")
-    dist_dir = tmpdir_factory.mktemp("dist")
+    build_dir = tmp_path_factory.mktemp("build")
+    dist_dir = tmp_path_factory.mktemp("dist")
     for dist in test_distributions:
         os.chdir(os.path.join(this_dir, "testdata", dist))
         subprocess.check_call(
@@ -51,7 +51,7 @@ def wheels_and_eggs(tmpdir_factory):
 
     os.chdir(pwd)
     return sorted(
-        str(fname) for fname in dist_dir.listdir() if fname.ext in (".whl", ".egg")
+        str(fname) for fname in dist_dir.iterdir() if fname.suffix in (".whl", ".egg")
     )
 
 

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -47,13 +47,15 @@ setup(
 
 
 @pytest.fixture
-def dummy_dist(tmpdir_factory):
-    basedir = tmpdir_factory.mktemp("dummy_dist")
-    basedir.join("setup.py").write(SETUPPY_EXAMPLE)
+def dummy_dist(tmp_path_factory):
+    basedir = tmp_path_factory.mktemp("dummy_dist")
+    basedir.joinpath("setup.py").write_text(SETUPPY_EXAMPLE, encoding="utf-8")
     for fname in DEFAULT_LICENSE_FILES | OTHER_IGNORED_FILES:
-        basedir.join(fname).write("")
+        basedir.joinpath(fname).write_text("", encoding="utf-8")
 
-    basedir.join("licenses").mkdir().join("DUMMYFILE").write("")
+    licensedir = basedir.joinpath("licenses")
+    licensedir.mkdir()
+    licensedir.joinpath("DUMMYFILE").write_text("", encoding="utf-8")
     return basedir
 
 
@@ -111,10 +113,10 @@ def test_preserve_unicode_metadata(monkeypatch, tmp_path):
     assert "UTF-8 描述 説明" in metadata
 
 
-def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
+def test_licenses_default(dummy_dist, monkeypatch, tmp_path):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
-        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"]
+        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmp_path), "--universal"]
     )
     with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
         license_files = {
@@ -123,11 +125,13 @@ def test_licenses_default(dummy_dist, monkeypatch, tmpdir):
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
-def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
-    dummy_dist.join("setup.cfg").write("[metadata]\nlicense_file=licenses/DUMMYFILE")
+def test_licenses_deprecated(dummy_dist, monkeypatch, tmp_path):
+    dummy_dist.joinpath("setup.cfg").write_text(
+        "[metadata]\nlicense_file=licenses/DUMMYFILE", encoding="utf-8"
+    )
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
-        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"]
+        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmp_path), "--universal"]
     )
     with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
         license_files = {"dummy_dist-1.0.dist-info/DUMMYFILE"}
@@ -147,11 +151,11 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmpdir):
         ),
     ],
 )
-def test_licenses_override(dummy_dist, monkeypatch, tmpdir, config_file, config):
-    dummy_dist.join(config_file).write(config)
+def test_licenses_override(dummy_dist, monkeypatch, tmp_path, config_file, config):
+    dummy_dist.joinpath(config_file).write_text(config, encoding="utf-8")
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
-        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"]
+        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmp_path), "--universal"]
     )
     with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
         license_files = {
@@ -160,17 +164,19 @@ def test_licenses_override(dummy_dist, monkeypatch, tmpdir, config_file, config)
         assert set(wf.namelist()) == DEFAULT_FILES | license_files
 
 
-def test_licenses_disabled(dummy_dist, monkeypatch, tmpdir):
-    dummy_dist.join("setup.cfg").write("[metadata]\nlicense_files=\n")
+def test_licenses_disabled(dummy_dist, monkeypatch, tmp_path):
+    dummy_dist.joinpath("setup.cfg").write_text(
+        "[metadata]\nlicense_files=\n", encoding="utf-8"
+    )
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
-        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmpdir), "--universal"]
+        [sys.executable, "setup.py", "bdist_wheel", "-b", str(tmp_path), "--universal"]
     )
     with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
         assert set(wf.namelist()) == DEFAULT_FILES
 
 
-def test_build_number(dummy_dist, monkeypatch, tmpdir):
+def test_build_number(dummy_dist, monkeypatch, tmp_path):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
         [
@@ -178,7 +184,7 @@ def test_build_number(dummy_dist, monkeypatch, tmpdir):
             "setup.py",
             "bdist_wheel",
             "-b",
-            str(tmpdir),
+            str(tmp_path),
             "--universal",
             "--build-number=2",
         ]
@@ -189,12 +195,12 @@ def test_build_number(dummy_dist, monkeypatch, tmpdir):
         assert "dummy_dist-1.0.dist-info/METADATA" in filenames
 
 
-def test_limited_abi(monkeypatch, tmpdir):
+def test_limited_abi(monkeypatch, tmp_path):
     """Test that building a binary wheel with the limited ABI works."""
     this_dir = os.path.dirname(__file__)
     source_dir = os.path.join(this_dir, "testdata", "extension.dist")
-    build_dir = tmpdir.join("build")
-    dist_dir = tmpdir.join("dist")
+    build_dir = tmp_path.joinpath("build")
+    dist_dir = tmp_path.joinpath("dist")
     monkeypatch.chdir(source_dir)
     subprocess.check_call(
         [
@@ -209,8 +215,8 @@ def test_limited_abi(monkeypatch, tmpdir):
     )
 
 
-def test_build_from_readonly_tree(dummy_dist, monkeypatch, tmpdir):
-    basedir = str(tmpdir.join("dummy"))
+def test_build_from_readonly_tree(dummy_dist, monkeypatch, tmp_path):
+    basedir = str(tmp_path.joinpath("dummy"))
     shutil.copytree(str(dummy_dist), basedir)
     monkeypatch.chdir(basedir)
 
@@ -227,7 +233,7 @@ def test_build_from_readonly_tree(dummy_dist, monkeypatch, tmpdir):
     list(bdist_wheel.supported_compressions.items()),
     ids=list(bdist_wheel.supported_compressions),
 )
-def test_compression(dummy_dist, monkeypatch, tmpdir, option, compress_type):
+def test_compression(dummy_dist, monkeypatch, tmp_path, option, compress_type):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
         [
@@ -235,7 +241,7 @@ def test_compression(dummy_dist, monkeypatch, tmpdir, option, compress_type):
             "setup.py",
             "bdist_wheel",
             "-b",
-            str(tmpdir),
+            str(tmp_path),
             "--universal",
             f"--compression={option}",
         ]
@@ -256,7 +262,7 @@ def test_wheelfile_line_endings(wheel_paths):
             assert b"\r" not in wheelfile_contents
 
 
-def test_unix_epoch_timestamps(dummy_dist, monkeypatch, tmpdir):
+def test_unix_epoch_timestamps(dummy_dist, monkeypatch, tmp_path):
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "0")
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(
@@ -265,7 +271,7 @@ def test_unix_epoch_timestamps(dummy_dist, monkeypatch, tmpdir):
             "setup.py",
             "bdist_wheel",
             "-b",
-            str(tmpdir),
+            str(tmp_path),
             "--universal",
             "--build-number=2",
         ]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from wheel.metadata import pkginfo_to_metadata
 
 
-def test_pkginfo_to_metadata(tmpdir):
+def test_pkginfo_to_metadata(tmp_path):
     expected_metadata = [
         ("Metadata-Version", "2.1"),
         ("Name", "spam"),
@@ -30,8 +30,8 @@ def test_pkginfo_to_metadata(tmpdir):
         ("Requires-Dist", "pytest-cov ; extra == 'test'"),
     ]
 
-    pkg_info = tmpdir.join("PKG-INFO")
-    pkg_info.write(
+    pkg_info = tmp_path.joinpath("PKG-INFO")
+    pkg_info.write_text(
         """\
 Metadata-Version: 0.0
 Name: spam
@@ -41,11 +41,13 @@ Provides-Extra: test
 Provides-Extra: reST
 Provides-Extra: signatures
 Provides-Extra: Signatures
-Provides-Extra: faster-signatures"""
+Provides-Extra: faster-signatures""",
+        encoding="utf-8",
     )
 
-    egg_info_dir = tmpdir.ensure_dir("test.egg-info")
-    egg_info_dir.join("requires.txt").write(
+    egg_info_dir = tmp_path.joinpath("test.egg-info")
+    egg_info_dir.mkdir(exist_ok=True)
+    egg_info_dir.joinpath("requires.txt").write_text(
         """\
 pip@https://github.com/pypa/pip/archive/1.3.1.zip
 
@@ -73,7 +75,8 @@ pyxdg
 
 [test]
 pytest>=3.0.0
-pytest-cov"""
+pytest-cov""",
+        encoding="utf-8",
     )
 
     message = pkginfo_to_metadata(

--- a/tests/test_tagopt.py
+++ b/tests/test_tagopt.py
@@ -26,26 +26,28 @@ EXT_MODULES = "ext_modules=[Extension('_test', sources=['test.c'])],"
 
 
 @pytest.fixture
-def temp_pkg(request, tmpdir):
-    tmpdir.join("test.py").write('print("Hello, world")')
+def temp_pkg(request, tmp_path):
+    tmp_path.joinpath("test.py").write_text('print("Hello, world")', encoding="utf-8")
 
     ext = getattr(request, "param", [False, ""])
     if ext[0]:
         # if ext[1] is not '', it will write a bad header and fail to compile
-        tmpdir.join("test.c").write("#include <std%sio.h>" % ext[1])
+        tmp_path.joinpath("test.c").write_text(
+            "#include <std%sio.h>" % ext[1], encoding="utf-8"
+        )
         setup_py = SETUP_PY.format(ext_modules=EXT_MODULES)
     else:
         setup_py = SETUP_PY.format(ext_modules="")
 
-    tmpdir.join("setup.py").write(setup_py)
+    tmp_path.joinpath("setup.py").write_text(setup_py, encoding="utf-8")
     if ext[0]:
         try:
             subprocess.check_call(
-                [sys.executable, "setup.py", "build_ext"], cwd=str(tmpdir)
+                [sys.executable, "setup.py", "build_ext"], cwd=str(tmp_path)
             )
         except subprocess.CalledProcessError:
             pytest.skip("Cannot compile C extensions")
-    return tmpdir
+    return tmp_path
 
 
 @pytest.mark.parametrize("temp_pkg", [[True, "xxx"]], indirect=["temp_pkg"])
@@ -57,12 +59,12 @@ def test_default_tag(temp_pkg):
     subprocess.check_call(
         [sys.executable, "setup.py", "bdist_wheel"], cwd=str(temp_pkg)
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename == f"Test-1.0-py{sys.version_info[0]}-none-any.whl"
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name == f"Test-1.0-py{sys.version_info[0]}-none-any.whl"
+    assert wheels[0].suffix == ".whl"
 
 
 def test_build_number(temp_pkg):
@@ -70,12 +72,12 @@ def test_build_number(temp_pkg):
         [sys.executable, "setup.py", "bdist_wheel", "--build-number=1"],
         cwd=str(temp_pkg),
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename == f"Test-1.0-1-py{sys.version_info[0]}-none-any.whl"
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name == f"Test-1.0-1-py{sys.version_info[0]}-none-any.whl"
+    assert wheels[0].suffix == ".whl"
 
 
 def test_explicit_tag(temp_pkg):
@@ -83,24 +85,24 @@ def test_explicit_tag(temp_pkg):
         [sys.executable, "setup.py", "bdist_wheel", "--python-tag=py32"],
         cwd=str(temp_pkg),
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.startswith("Test-1.0-py32-")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.startswith("Test-1.0-py32-")
+    assert wheels[0].suffix == ".whl"
 
 
 def test_universal_tag(temp_pkg):
     subprocess.check_call(
         [sys.executable, "setup.py", "bdist_wheel", "--universal"], cwd=str(temp_pkg)
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.startswith("Test-1.0-py2.py3-")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.startswith("Test-1.0-py2.py3-")
+    assert wheels[0].suffix == ".whl"
 
 
 def test_universal_beats_explicit_tag(temp_pkg):
@@ -108,51 +110,55 @@ def test_universal_beats_explicit_tag(temp_pkg):
         [sys.executable, "setup.py", "bdist_wheel", "--universal", "--python-tag=py32"],
         cwd=str(temp_pkg),
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.startswith("Test-1.0-py2.py3-")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.startswith("Test-1.0-py2.py3-")
+    assert wheels[0].suffix == ".whl"
 
 
 def test_universal_in_setup_cfg(temp_pkg):
-    temp_pkg.join("setup.cfg").write("[bdist_wheel]\nuniversal=1")
+    temp_pkg.joinpath("setup.cfg").write_text(
+        "[bdist_wheel]\nuniversal=1", encoding="utf-8"
+    )
     subprocess.check_call(
         [sys.executable, "setup.py", "bdist_wheel"], cwd=str(temp_pkg)
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.startswith("Test-1.0-py2.py3-")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.startswith("Test-1.0-py2.py3-")
+    assert wheels[0].suffix == ".whl"
 
 
 def test_pythontag_in_setup_cfg(temp_pkg):
-    temp_pkg.join("setup.cfg").write("[bdist_wheel]\npython_tag=py32")
+    temp_pkg.joinpath("setup.cfg").write_text(
+        "[bdist_wheel]\npython_tag=py32", encoding="utf-8"
+    )
     subprocess.check_call(
         [sys.executable, "setup.py", "bdist_wheel"], cwd=str(temp_pkg)
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.startswith("Test-1.0-py32-")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.startswith("Test-1.0-py32-")
+    assert wheels[0].suffix == ".whl"
 
 
 def test_legacy_wheel_section_in_setup_cfg(temp_pkg):
-    temp_pkg.join("setup.cfg").write("[wheel]\nuniversal=1")
+    temp_pkg.joinpath("setup.cfg").write_text("[wheel]\nuniversal=1", encoding="utf-8")
     subprocess.check_call(
         [sys.executable, "setup.py", "bdist_wheel"], cwd=str(temp_pkg)
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.startswith("Test-1.0-py2.py3-")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.startswith("Test-1.0-py2.py3-")
+    assert wheels[0].suffix == ".whl"
 
 
 def test_plat_name_purepy(temp_pkg):
@@ -160,12 +166,12 @@ def test_plat_name_purepy(temp_pkg):
         [sys.executable, "setup.py", "bdist_wheel", "--plat-name=testplat.pure"],
         cwd=str(temp_pkg),
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.endswith("-testplat_pure.whl")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.endswith("-testplat_pure.whl")
+    assert wheels[0].suffix == ".whl"
 
 
 @pytest.mark.parametrize("temp_pkg", [[True, ""]], indirect=["temp_pkg"])
@@ -175,37 +181,41 @@ def test_plat_name_ext(temp_pkg):
         cwd=str(temp_pkg),
     )
 
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.endswith("-testplat_arch.whl")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.endswith("-testplat_arch.whl")
+    assert wheels[0].suffix == ".whl"
 
 
 def test_plat_name_purepy_in_setupcfg(temp_pkg):
-    temp_pkg.join("setup.cfg").write("[bdist_wheel]\nplat_name=testplat.pure")
+    temp_pkg.joinpath("setup.cfg").write_text(
+        "[bdist_wheel]\nplat_name=testplat.pure", encoding="utf-8"
+    )
     subprocess.check_call(
         [sys.executable, "setup.py", "bdist_wheel"], cwd=str(temp_pkg)
     )
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.endswith("-testplat_pure.whl")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.endswith("-testplat_pure.whl")
+    assert wheels[0].suffix == ".whl"
 
 
 @pytest.mark.parametrize("temp_pkg", [[True, ""]], indirect=["temp_pkg"])
 def test_plat_name_ext_in_setupcfg(temp_pkg):
-    temp_pkg.join("setup.cfg").write("[bdist_wheel]\nplat_name=testplat.arch")
+    temp_pkg.joinpath("setup.cfg").write_text(
+        "[bdist_wheel]\nplat_name=testplat.arch", encoding="utf-8"
+    )
     subprocess.check_call(
         [sys.executable, "setup.py", "bdist_wheel"], cwd=str(temp_pkg)
     )
 
-    dist_dir = temp_pkg.join("dist")
-    assert dist_dir.check(dir=1)
-    wheels = dist_dir.listdir()
+    dist_dir = temp_pkg.joinpath("dist")
+    assert dist_dir.is_dir()
+    wheels = list(dist_dir.iterdir())
     assert len(wheels) == 1
-    assert wheels[0].basename.endswith("-testplat_arch.whl")
-    assert wheels[0].ext == ".whl"
+    assert wheels[0].name.endswith("-testplat_arch.whl")
+    assert wheels[0].suffix == ".whl"

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -10,8 +10,8 @@ from wheel.wheelfile import WheelFile
 
 
 @pytest.fixture
-def wheel_path(tmpdir):
-    return str(tmpdir.join("test-1.0-py2.py3-none-any.whl"))
+def wheel_path(tmp_path):
+    return str(tmp_path.joinpath("test-1.0-py2.py3-none-any.whl"))
 
 
 @pytest.mark.parametrize(
@@ -21,9 +21,9 @@ def wheel_path(tmpdir):
         "foo-2-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     ],
 )
-def test_wheelfile_re(filename, tmpdir):
+def test_wheelfile_re(filename, tmp_path):
     # Regression test for #208 and #485
-    path = tmpdir.join(filename)
+    path = tmp_path.joinpath(filename)
     with WheelFile(str(path), "w") as wf:
         assert wf.parsed_filename.group("namever") == "foo-2"
 
@@ -147,12 +147,12 @@ def test_write_str(wheel_path):
         )
 
 
-def test_timestamp(tmpdir_factory, wheel_path, monkeypatch):
+def test_timestamp(tmp_path_factory, wheel_path, monkeypatch):
     # An environment variable can be used to influence the timestamp on
     # TarInfo objects inside the zip.  See issue #143.
-    build_dir = tmpdir_factory.mktemp("build")
+    build_dir = tmp_path_factory.mktemp("build")
     for filename in ("one", "two", "three"):
-        build_dir.join(filename).write(filename + "\n")
+        build_dir.joinpath(filename).write_text(filename + "\n", encoding="utf-8")
 
     # The earliest date representable in TarInfos, 1980-01-01
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "315576060")
@@ -169,14 +169,14 @@ def test_timestamp(tmpdir_factory, wheel_path, monkeypatch):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Windows does not support UNIX-like permissions"
 )
-def test_attributes(tmpdir_factory, wheel_path):
+def test_attributes(tmp_path_factory, wheel_path):
     # With the change from ZipFile.write() to .writestr(), we need to manually
     # set member attributes.
-    build_dir = tmpdir_factory.mktemp("build")
+    build_dir = tmp_path_factory.mktemp("build")
     files = (("foo", 0o644), ("bar", 0o755))
     for filename, mode in files:
-        path = build_dir.join(filename)
-        path.write(filename + "\n")
+        path = build_dir.joinpath(filename)
+        path.write_text(filename + "\n", encoding="utf-8")
         path.chmod(mode)
 
     with WheelFile(wheel_path, "w") as wf:


### PR DESCRIPTION
This uses pathlib-based tmp_path instead of py.path based tmpdir fixtures. Should be fine for pytest 6+, I think. Came up in the context of #512, though you can't quite remove the `_pytest` warning suppression, as there's one remaining thing in pytest that is missing an encoding.
