### PR TITLE
fix: pipx run incompatible with wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ wheel = "wheel.cli:main"
 [project.entry-points."distutils.commands"]
 bdist_wheel = "wheel.bdist_wheel:bdist_wheel"
 
+[project.entry-points."pipx.run"]
+wheel = "wheel.cli:main"
+
 [project.optional-dependencies]
 test = [
     "pytest >= 6.0.0"


### PR DESCRIPTION
Pipx adds setuptools and wheel to the default environment, but filters out the "wheel" executable, otherwise it would get added with every pipx environment and clash. But that also means you can't `pipx run wheel`. I think this is the simplest solution, but it should be verified that `pip install wheel` works; if not, then it probably needs a fix within pipx instead. Draft until this is worked out. See https://github.com/pypa/pipx/issues/951.
