### PR TITLE
chore: remove unused license line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 authors = [{name = "Daniel Holth", email = "dholth@fastmail.fm"}]
 maintainers = [{name = "Alex Grönholm", email = "alex.gronholm@nextday.fi"}]
 keywords = ["wheel", "packaging"]
-license = {file = "LICENSE.txt"}
 requires-python = ">=3.7"
 dynamic = ["version"]
 


### PR DESCRIPTION
This line doesn't do anything, as flit-core ignores it - the METADATA doesn't have a place for a full-text license. The license is specified via trove classifiers, and Flit automatically includes LICENSE* in the dist-info directory, `wheel-0.40.0.dist-info/LICENSE.txt` is still present after this change. See #518.