### PR TITLE
Allowed string components after initial number of build tags in `wheel tags`

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+**UNRELEASED**
+
+- Added full support of the build tag syntax to ``wheel tags`` (you can now set a build
+  tag like ``123mytag``)
+
 **0.40.0 (2023-03-14)**
 
 - Added a ``wheel tags`` command to modify tags on an existing wheel

--- a/src/wheel/cli/__init__.py
+++ b/src/wheel/cli/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from argparse import ArgumentTypeError
 
 
 class WheelError(Exception):
@@ -54,6 +55,15 @@ def version_f(args):
     from .. import __version__
 
     print("wheel %s" % __version__)
+
+
+def parse_build_tag(build_tag: str):
+    if not build_tag[0].isdigit():
+        raise ArgumentTypeError("build tag must begin with a digit")
+    elif "-" in build_tag:
+        raise ArgumentTypeError("invalid character ('-') in build tag")
+
+    return build_tag
 
 
 TAGS_HELP = """\
@@ -117,7 +127,7 @@ def parser():
         "--platform-tag", metavar="TAG", help="Specify a platform tag(s)"
     )
     tags_parser.add_argument(
-        "--build", type=int, metavar="NUMBER", help="Specify a build number"
+        "--build", type=parse_build_tag, metavar="BUILD", help="Specify a build tag"
     )
     tags_parser.set_defaults(func=tags_f)
 

--- a/src/wheel/cli/__init__.py
+++ b/src/wheel/cli/__init__.py
@@ -57,7 +57,7 @@ def version_f(args):
     print("wheel %s" % __version__)
 
 
-def parse_build_tag(build_tag: str):
+def parse_build_tag(build_tag: str) -> str:
     if not build_tag[0].isdigit():
         raise ArgumentTypeError("build tag must begin with a digit")
     elif "-" in build_tag:

--- a/src/wheel/cli/tags.py
+++ b/src/wheel/cli/tags.py
@@ -27,7 +27,7 @@ def tags(
     python_tags: str | None = None,
     abi_tags: str | None = None,
     platform_tags: str | None = None,
-    build_number: int | None = None,
+    build_tag: str | None = None,
     remove: bool = False,
 ) -> str:
     """Change the tags on a wheel file.
@@ -41,7 +41,7 @@ def tags(
     :param python_tags: The Python tags to set
     :param abi_tags: The ABI tags to set
     :param platform_tags: The platform tags to set
-    :param build_number: The build number to set
+    :param build_tag: The build tag to set
     :param remove: Remove the original wheel
     """
     with WheelFile(wheel, "r") as f:
@@ -56,7 +56,7 @@ def tags(
         original_abi_tags = f.parsed_filename.group("abi").split(".")
         original_plat_tags = f.parsed_filename.group("plat").split(".")
 
-    tags, existing_build_number = read_tags(wheel_info)
+    tags, existing_build_tag = read_tags(wheel_info)
 
     impls = {tag.split("-")[0] for tag in tags}
     abivers = {tag.split("-")[1] for tag in tags}
@@ -76,16 +76,16 @@ def tags(
         )
         raise AssertionError(msg)
 
-    if existing_build_number != build:
+    if existing_build_tag != build:
         msg = (
             f"Incorrect filename '{build}' "
-            "& *.dist-info/WHEEL '{existing_build_number}' build numbers"
+            f"& *.dist-info/WHEEL '{existing_build_tag}' build numbers"
         )
         raise AssertionError(msg)
 
     # Start changing as needed
-    if build_number is not None:
-        build = str(build_number)
+    if build_tag is not None:
+        build = build_tag
 
     final_python_tags = sorted(_compute_tags(original_python_tags, python_tags))
     final_abi_tags = sorted(_compute_tags(original_abi_tags, abi_tags))

--- a/tests/cli/test_tags.py
+++ b/tests/cli/test_tags.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import shutil
+import sys
 from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
 
-from wheel.cli import parser
+from wheel.cli import main, parser
 from wheel.cli.tags import tags
 from wheel.wheelfile import WheelFile
 
@@ -110,12 +111,29 @@ def test_plat_tags(wheelpath):
     assert TESTWHEEL_NAME == newname
 
 
-def test_build_number(wheelpath):
-    newname = tags(str(wheelpath), build_number=1)
-    assert TESTWHEEL_NAME.replace("-py2", "-1-py2") == newname
+def test_build_tag(wheelpath):
+    newname = tags(str(wheelpath), build_tag="1bah")
+    assert TESTWHEEL_NAME.replace("-py2", "-1bah-py2") == newname
     output_file = wheelpath.parent / newname
     assert output_file.exists()
     output_file.unlink()
+
+
+@pytest.mark.parametrize(
+    "build_tag, error",
+    [
+        pytest.param("foo", "build tag must begin with a digit", id="digitstart"),
+        pytest.param("1-f", "invalid character ('-') in build tag", id="hyphen"),
+    ],
+)
+def test_invalid_build_tag(wheelpath, build_tag, error, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", [sys.argv[0], "tags", "--build", build_tag])
+    with pytest.raises(SystemExit) as exc:
+        main()
+
+    _, err = capsys.readouterr()
+    assert exc.value.args[0] == 2
+    assert f"error: argument --build: {error}" in err
 
 
 def test_multi_tags(wheelpath):
@@ -123,7 +141,7 @@ def test_multi_tags(wheelpath):
         str(wheelpath),
         platform_tags="linux_x86_64",
         python_tags="+py4",
-        build_number=1,
+        build_tag="1",
     )
     assert "test-1.0-1-py2.py3.py4-none-linux_x86_64.whl" == newname
 


### PR DESCRIPTION
Fixes #527.