### PR TITLE
CI: Start testing Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip-test-${{ matrix.python-version }}-${{ matrix.os }}
+    - name: Install setuptools
+      run: pip install setuptools
     - name: Install the project
       run: pip install --no-binary=wheel .
     - name: Install test dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8", "pypy-3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8", "pypy-3.9"]
         include:
         - os: macos-latest
           python-version: "3.7"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8", "pypy-3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.9"]
         include:
         - os: macos-latest
           python-version: "3.7"
@@ -35,12 +35,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: pip-test-${{ matrix.python-version }}-${{ matrix.os }}
-    - name: Install setuptools
-      run: pip install setuptools
     - name: Install the project
       run: pip install --no-binary=wheel .
     - name: Install test dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ bdist_wheel = "wheel.bdist_wheel:bdist_wheel"
 
 [project.optional-dependencies]
 test = [
-    "pytest >= 6.0.0"
+    "pytest >= 6.0.0",
+    "setuptools >= 65"
 ]
 
 [tool.flit.sdist]


### PR DESCRIPTION
Add Python 3.12 to the Ubuntu job matrix to start testing the betas in the CI.