### PR TITLE
chore: both ruff and black read requires-python now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ exclude = [
 ]
 
 [tool.black]
-target-version = ['py37']
 extend-exclude = '''
 ^/src/wheel/vendored/
 '''
@@ -100,7 +99,6 @@ select = [
     "UP",           # pyupgrade
     "B0",           # flake8-bugbear
 ]
-target-version = "py37"
 src = ["src"]
 
 [tool.tox]


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.