### PR TITLE
ci: make patch coverage informational only

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This should make patch coverage only informational.
