### PR TITLE
Fix `bdist_wheel.data_dir` in the presence of local version segment given via `tag_build`

### DIFF
--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -232,6 +232,9 @@ class bdist_wheel(Command):
             bdist_base = self.get_finalized_command("bdist").bdist_base
             self.bdist_dir = os.path.join(bdist_base, "wheel")
 
+        egg_info = self.distribution.get_command_obj("egg_info")
+        egg_info.ensure_finalized()  # needed for correct `wheel_dist_name`
+
         self.data_dir = self.wheel_dist_name + ".data"
         self.plat_name_supplied = self.plat_name is not None
 


### PR DESCRIPTION
Setuptools allow authors to set PEP 440's local version segments using ``egg_info.tag_build``.
This should be reflected not only in the ``.whl`` file name, but also in the ``.dist-info`` and ``.data`` dirs.

The implemented behaviour currently seems to be inconsistent, while the `.whl` file and the `.dist-info` do contain the local version segment, the `.data` directory seems to lack it.

This problem was originally reported in the setuptools repository, please check pypa/setuptools#3997 for more details.

Fixes pypa/setuptools#3997