### PR TITLE
Don't wrap version specifiers in parens in Requires-Dist

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -5,6 +5,7 @@ Release Notes
 
 - Fixed naming of the ``data_dir`` directory in the presence of local version segment
   given via ``egg_info.tag_build`` (PR by Anderson Bravalheri)
+- Fixed version specifiers in ``Requires-Dist`` being wrapped in parentheses
 
 **0.41.0 (2023-07-22)**
 

--- a/src/wheel/metadata.py
+++ b/src/wheel/metadata.py
@@ -92,7 +92,7 @@ def requires_to_requires_dist(requirement: Requirement) -> str:
         requires_dist.append(spec.operator + spec.version)
 
     if requires_dist:
-        return " (" + ",".join(sorted(requires_dist)) + ")"
+        return " " + ",".join(sorted(requires_dist))
     else:
         return ""
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -22,11 +22,11 @@ def test_pkginfo_to_metadata(tmp_path):
         ("Provides-Extra", "faster-signatures"),
         ("Requires-Dist", "ed25519ll ; extra == 'faster-signatures'"),
         ("Provides-Extra", "rest"),
-        ("Requires-Dist", "docutils (>=0.8) ; extra == 'rest'"),
+        ("Requires-Dist", "docutils >=0.8 ; extra == 'rest'"),
         ("Requires-Dist", "keyring ; extra == 'signatures'"),
         ("Requires-Dist", "keyrings.alt ; extra == 'signatures'"),
         ("Provides-Extra", "test"),
-        ("Requires-Dist", "pytest (>=3.0.0) ; extra == 'test'"),
+        ("Requires-Dist", "pytest >=3.0.0 ; extra == 'test'"),
         ("Requires-Dist", "pytest-cov ; extra == 'test'"),
     ]
 


### PR DESCRIPTION
Fixes #551.