### PR TITLE
docs: use modern readthedocs build image selection

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,18 @@
 version: 2
-formats: [htmlzip, pdf]
+
+formats:
+  - htmlzip
+  - pdf
+
+sphinx:
+  configuration: docs/conf.py
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 python:
-   version: "3.7"
    install:
       - method: pip
         path: .


### PR DESCRIPTION
This is now the recommendation for readthedocs [example](https://about.readthedocs.com/?ref=dotorg-homepage), [docs](https://docs.readthedocs.io/en/stable/config-file/v2.html#supported-settings).

The old legacy settings are covered [here](https://docs.readthedocs.io/en/stable/config-file/v2.html#legacy-build-specification).

Discovered via [sp-repo-review](https://learn.scientific-python.org/development/guides/repo-review/?repo=pypa%2Fwheel&branch=main).
