### PR TITLE
Produce correct ABI tags for GraalPy

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,7 @@ Release Notes
   kernel (PR by Matthieu Darbois)
 - Fixed ``wheel tags`` to not list directories in ``RECORD`` files
   (PR by Mike Taves)
+- Fixed ABI tag generation for GraalPy (PR by Michael Simacek)
 
 **0.41.1 (2023-08-05)**
 

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -113,6 +113,9 @@ def get_abi_tag():
         # we want something like pypy36-pp73
         abi = "-".join(soabi.split("-")[:2])
         abi = abi.replace(".", "_").replace("-", "_")
+    elif soabi and impl == "graalpy":
+        abi = "-".join(soabi.split("-")[:3])
+        abi = abi.replace(".", "_").replace("-", "_")
     elif soabi:
         abi = soabi.replace(".", "_").replace("-", "_")
     else:

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -285,16 +285,28 @@ def test_unix_epoch_timestamps(dummy_dist, monkeypatch, tmp_path):
     )
 
 
-def test_get_abi_tag_old(monkeypatch):
+def test_get_abi_tag_pypy_old(monkeypatch):
     monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
     monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "pypy36-pp73")
     assert get_abi_tag() == "pypy36_pp73"
 
 
-def test_get_abi_tag_new(monkeypatch):
+def test_get_abi_tag_pypy_new(monkeypatch):
     monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "pypy37-pp73-darwin")
     monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
     assert get_abi_tag() == "pypy37_pp73"
+
+
+def test_get_abi_tag_graalpy(monkeypatch):
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "graalpy231-310-native-x86_64-linux")
+    monkeypatch.setattr(tags, "interpreter_name", lambda: "graalpy")
+    assert get_abi_tag() == "graalpy231_310_native"
+
+
+def test_get_abi_tag_fallback(monkeypatch):
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "unknown-python-310")
+    monkeypatch.setattr(tags, "interpreter_name", lambda: "unknown-python")
+    assert get_abi_tag() == "unknown_python_310"
 
 
 def test_platform_with_space(dummy_dist, monkeypatch):

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -298,7 +298,9 @@ def test_get_abi_tag_pypy_new(monkeypatch):
 
 
 def test_get_abi_tag_graalpy(monkeypatch):
-    monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "graalpy231-310-native-x86_64-linux")
+    monkeypatch.setattr(
+        sysconfig, "get_config_var", lambda x: "graalpy231-310-native-x86_64-linux"
+    )
     monkeypatch.setattr(tags, "interpreter_name", lambda: "graalpy")
     assert get_abi_tag() == "graalpy231_310_native"
 


### PR DESCRIPTION
https://github.com/pypa/packaging/pull/607 changed the ABI tag computation for [GraalPy](https://github.com/oracle/graalpython). This results in the current wheel not working for GraalPy because it uses pypa/packaging to validate tags of newly built wheels and now it always rejects them as mismatched. We need a corresponding change in wheel's tag computation, like it was done for PyPy in https://github.com/pypa/wheel/pull/373. Our SOABI look something like `graalpy231-310-native-x86_64-linux`, so the expected ABI tag for that is `graalpy231_310_native`. Compared to PyPy's there is one more component to distinguish native and sandboxed modes.

CC @timfel