### PR TITLE
Skip adding directories to RECORD with `wheel tags`

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -5,6 +5,8 @@ Release Notes
 
 - Fixed platform tag detection for GraalPy and 32-bit python running on an aarch64
   kernel (PR by Matthieu Darbois)
+- Fixed ``wheel tags`` to not list directories in ``RECORD`` files
+  (PR by Mike Taves)
 
 **0.41.1 (2023-08-05)**
 

--- a/src/wheel/cli/tags.py
+++ b/src/wheel/cli/tags.py
@@ -120,6 +120,8 @@ def tags(
         ) as fout:
             fout.comment = fin.comment  # preserve the comment
             for item in fin.infolist():
+                if item.is_dir():
+                    continue
                 if item.filename == f.dist_info_path + "/RECORD":
                     continue
                 if item.filename == f.dist_info_path + "/WHEEL":

--- a/tests/cli/test_tags.py
+++ b/tests/cli/test_tags.py
@@ -222,11 +222,15 @@ def test_permission_bits(capsys, wheelpath):
     with ZipFile(str(output_file), "r") as outf:
         with ZipFile(str(wheelpath), "r") as inf:
             for member in inf.namelist():
-                if not member.endswith("/RECORD"):
-                    out_attr = outf.getinfo(member).external_attr
-                    inf_attr = inf.getinfo(member).external_attr
-                    assert (
-                        out_attr == inf_attr
-                    ), f"{member} 0x{out_attr:012o} != 0x{inf_attr:012o}"
+                member_info = inf.getinfo(member)
+                if member_info.is_dir():
+                    continue
+                if member_info.filename.endswith("/RECORD"):
+                    continue
+                out_attr = outf.getinfo(member).external_attr
+                inf_attr = member_info.external_attr
+                assert (
+                    out_attr == inf_attr
+                ), f"{member} 0x{out_attr:012o} != 0x{inf_attr:012o}"
 
     output_file.unlink()

--- a/tests/cli/test_tags.py
+++ b/tests/cli/test_tags.py
@@ -225,7 +225,7 @@ def test_permission_bits(capsys, wheelpath):
                 member_info = inf.getinfo(member)
                 if member_info.is_dir():
                     continue
-                
+
                 if member_info.filename.endswith("/RECORD"):
                     continue
 

--- a/tests/cli/test_tags.py
+++ b/tests/cli/test_tags.py
@@ -225,8 +225,10 @@ def test_permission_bits(capsys, wheelpath):
                 member_info = inf.getinfo(member)
                 if member_info.is_dir():
                     continue
+                
                 if member_info.filename.endswith("/RECORD"):
                     continue
+
                 out_attr = outf.getinfo(member).external_attr
                 inf_attr = member_info.external_attr
                 assert (


### PR DESCRIPTION
Closes #558

<s>Tests are not included yet, but advice would be welcome. The example with tests/test_tagopt.py would probably needed to be modified to add some dummy [data files](https://setuptools.pypa.io/en/latest/userguide/datafiles.html) in a subdir.</s> Some testing has been modified, but advice on more is welcome.

<s>This PR also removes (now) unnecessary use of OrderedDict, and tidies a str concat.</s>