### PR TITLE
Remove use of OrderedDict, simplify a str concat

### DIFF
--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -14,7 +14,6 @@ import struct
 import sys
 import sysconfig
 import warnings
-from collections import OrderedDict
 from email.generator import BytesGenerator, Generator
 from email.policy import EmailPolicy
 from glob import iglob
@@ -152,9 +151,10 @@ def remove_readonly_exc(func, path, exc):
 class bdist_wheel(Command):
     description = "create a wheel distribution"
 
-    supported_compressions = OrderedDict(
-        [("stored", ZIP_STORED), ("deflated", ZIP_DEFLATED)]
-    )
+    supported_compressions = {
+        "stored": ZIP_STORED,
+        "deflated": ZIP_DEFLATED,
+    }
 
     user_options = [
         ("bdist-dir=", "b", "temporary directory for creating the distribution"),
@@ -168,7 +168,7 @@ class bdist_wheel(Command):
             "keep-temp",
             "k",
             "keep the pseudo-installation tree around after "
-            + "creating the distribution archive",
+            "creating the distribution archive",
         ),
         ("dist-dir=", "d", "directory to put final built distributions in"),
         ("skip-build", None, "skip rebuilding everything (for testing/debugging)"),

--- a/src/wheel/wheelfile.py
+++ b/src/wheel/wheelfile.py
@@ -6,7 +6,6 @@ import os.path
 import re
 import stat
 import time
-from collections import OrderedDict
 from io import StringIO, TextIOWrapper
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
@@ -50,7 +49,7 @@ class WheelFile(ZipFile):
             self.parsed_filename.group("namever")
         )
         self.record_path = self.dist_info_path + "/RECORD"
-        self._file_hashes = OrderedDict()
+        self._file_hashes = {}
         self._file_sizes = {}
         if mode == "r":
             # Ignore RECORD and any embedded wheel signatures


### PR DESCRIPTION
Since Python 3.7 the insertion order to `dict` has been preserved, thus OrderedDict is no longer necessary.