### PR TITLE
chore: add [convert] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ wheel = "wheel.cli:main"
 bdist_wheel = "wheel.bdist_wheel:bdist_wheel"
 
 [project.optional-dependencies]
+convert = [
+    "setuptools",
+]
 test = [
     "pytest >= 6.0.0",
     "setuptools >= 65",


### PR DESCRIPTION
Fix #510 by adding an extra for `wheel convert`.