### PR TITLE
Fix ABI tag for CPython 3.13 on Windows

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,7 +3,7 @@ Release Notes
 
 **UNRELEASED**
 
-- Fixed ABI tag generation for CPython 3.13a1 on Windows (PR by Sam Goss)
+- Fixed ABI tag generation for CPython 3.13a1 on Windows (PR by Sam Gross)
 
 **0.41.2 (2023-08-22)**
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,7 +3,7 @@ Release Notes
 
 **UNRELEASED**
 
-- Fixed ABI tag generation for CPython 3.13a1 on Windows
+- Fixed ABI tag generation for CPython 3.13a1 on Windows (PR by Sam Goss)
 
 **0.41.2 (2023-08-22)**
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+**UNRELEASED**
+
+- Fixed ABI tag generation for CPython 3.13a1 on Windows.
+
 **0.41.2 (2023-08-22)**
 
 - Fixed platform tag detection for GraalPy and 32-bit python running on an aarch64

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,7 +3,7 @@ Release Notes
 
 **UNRELEASED**
 
-- Fixed ABI tag generation for CPython 3.13a1 on Windows.
+- Fixed ABI tag generation for CPython 3.13a1 on Windows
 
 **0.41.2 (2023-08-22)**
 

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -117,7 +117,11 @@ def get_abi_tag():
             m = "m"
 
         abi = f"{impl}{tags.interpreter_version()}{d}{m}{u}"
-    elif soabi and impl == "cp":
+    elif soabi and impl == "cp" and soabi.startswith("cp"):
+        # Windows
+        abi = soabi.split("-")[0]
+    elif soabi and impl == "cp" and soabi.startswith("cpython"):
+        # non-Windows
         abi = "cp" + soabi.split("-")[1]
     elif soabi and impl == "pp":
         # we want something like pypy36-pp73

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -117,12 +117,12 @@ def get_abi_tag():
             m = "m"
 
         abi = f"{impl}{tags.interpreter_version()}{d}{m}{u}"
-    elif soabi and impl == "cp" and soabi.startswith("cp"):
-        # Windows
-        abi = soabi.split("-")[0]
     elif soabi and impl == "cp" and soabi.startswith("cpython"):
         # non-Windows
         abi = "cp" + soabi.split("-")[1]
+    elif soabi and impl == "cp" and soabi.startswith("cp"):
+        # Windows
+        abi = soabi.split("-")[0]
     elif soabi and impl == "pp":
         # we want something like pypy36-pp73
         abi = "-".join(soabi.split("-")[:2])

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -287,6 +287,12 @@ def test_unix_epoch_timestamps(dummy_dist, monkeypatch, tmp_path):
     )
 
 
+def test_get_abi_tag_windows(monkeypatch):
+    monkeypatch.setattr(tags, "interpreter_name", lambda: "cp")
+    monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "cp313-win_amd64")
+    assert get_abi_tag() == "cp313"
+
+
 def test_get_abi_tag_pypy_old(monkeypatch):
     monkeypatch.setattr(tags, "interpreter_name", lambda: "pp")
     monkeypatch.setattr(sysconfig, "get_config_var", lambda x: "pypy36-pp73")


### PR DESCRIPTION
CPython 3.13a1 on Windows now provides the SOABI sysconfig variable. However, the SOABI (and extension suffixes) are different on Windows than on Linux and macOS, e.g. `cp310-win_amd64` vs. `cpython-313-darwin`.

Fixes #576