### PR TITLE
Remove duplicate seek test

### DIFF
--- a/src/wheel/macosx_libfile.py
+++ b/src/wheel/macosx_libfile.py
@@ -340,9 +340,7 @@ def read_mach_header(lib_file, seek=None):
 
     :param lib_file: reference to opened library file with pointer
     """
-    if seek is not None:
-        lib_file.seek(seek)
-    base_class, magic_number = get_base_class_and_magic_number(lib_file)
+    base_class, magic_number = get_base_class_and_magic_number(lib_file, seek)
     arch = "32" if magic_number == MH_MAGIC else "64"
 
     class SegmentBase(base_class):


### PR DESCRIPTION
Function `get_base_class_and_magic_number()` already tests the value of `seek`, followed by a `seek()` call if needed. No need to duplicate the code in calling function `read_mach_header()`.

Fixes https://github.com/pypa/wheel/pull/591#issuecomment-1860528615.