### PR TITLE
The virtualenv Google group does not exist any more

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,6 @@
 wheel
 =====
 
-`Dev list <https://mail.python.org/archives/list/distutils-sig@python.org/>`_ |
 `GitHub <https://github.com/pypa/wheel>`_ |
 `PyPI <https://pypi.org/pypi/wheel/>`_ |
 User IRC: #pypa |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,6 @@
 wheel
 =====
 
-`User list <http://groups.google.com/group/python-virtualenv>`_ |
 `Dev list <https://mail.python.org/archives/list/distutils-sig@python.org/>`_ |
 `GitHub <https://github.com/pypa/wheel>`_ |
 `PyPI <https://pypi.org/pypi/wheel/>`_ |


### PR DESCRIPTION
And the dev list has been archived.

Perhaps replace with https://discuss.python.org? 