### PR TITLE
Reduce frequency of pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,6 @@ repos:
   - id: rst-backticks
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
+
+ci:
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
I was reading through the history of `wheel` and a lot of it is autoupdate. Opening this PR in case it's welcome, feel free to close!