### PR TITLE
Support passing dist-info-dir to bdist_wheel

### DIFF
--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -224,7 +224,8 @@ class bdist_wheel(Command):
             None,
             "directory where a pre-generated dist-info can be found (e.g. as a "
             "result of calling the PEP517 'prepare_metadata_for_build_wheel' "
-            "method)"),
+            "method)",
+        ),
     ]
 
     boolean_options = ["keep-temp", "skip-build", "relative", "universal"]

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -219,6 +219,12 @@ class bdist_wheel(Command):
             None,
             "Python tag (cp32|cp33|cpNN) for abi3 wheel tag" " (default: false)",
         ),
+        (
+            "dist-info-dir=",
+            None,
+            "directory where a pre-generated dist-info can be found (e.g. as a "
+            "result of calling the PEP517 'prepare_metadata_for_build_wheel' "
+            "method)"),
     ]
 
     boolean_options = ["keep-temp", "skip-build", "relative", "universal"]
@@ -231,6 +237,7 @@ class bdist_wheel(Command):
         self.format = "zip"
         self.keep_temp = False
         self.dist_dir = None
+        self.dist_info_dir = None
         self.egginfo_dir = None
         self.root_is_pure = None
         self.skip_build = None
@@ -249,8 +256,9 @@ class bdist_wheel(Command):
             bdist_base = self.get_finalized_command("bdist").bdist_base
             self.bdist_dir = os.path.join(bdist_base, "wheel")
 
-        egg_info = self.distribution.get_command_obj("egg_info")
-        egg_info.ensure_finalized()  # needed for correct `wheel_dist_name`
+        if self.dist_info_dir is None:
+            egg_info = self.distribution.get_command_obj("egg_info")
+            egg_info.ensure_finalized()  # needed for correct `wheel_dist_name`
 
         self.data_dir = self.wheel_dist_name + ".data"
         self.plat_name_supplied = self.plat_name is not None
@@ -412,12 +420,21 @@ class bdist_wheel(Command):
             )
 
         self.set_undefined_options("install_egg_info", ("target", "egginfo_dir"))
+
         distinfo_dirname = (
             f"{safer_name(self.distribution.get_name())}-"
             f"{safer_version(self.distribution.get_version())}.dist-info"
         )
         distinfo_dir = os.path.join(self.bdist_dir, distinfo_dirname)
-        self.egg2dist(self.egginfo_dir, distinfo_dir)
+        if self.dist_info_dir:
+            # Use the given dist-info directly.
+            shutil.copytree(self.dist_info_dir, distinfo_dir)
+            # Egg info is still generated, so remove it now to avoid it getting
+            # copied into the wheel.
+            shutil.rmtree(self.egginfo_dir)
+        else:
+            # Convert the generated egg-info into dist-info.
+            self.egg2dist(self.egginfo_dir, distinfo_dir)
 
         self.write_wheelfile(distinfo_dir)
 

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -127,23 +127,28 @@ def test_dist_info_provided(dummy_dist, monkeypatch, tmp_path):
     monkeypatch.chdir(dummy_dist)
     distinfo = tmp_path / "dummy_dist.dist-info"
     distinfo.mkdir()
-    (distinfo / 'METADATA').write_text("name: helloworld", encoding="utf-8")
+    (distinfo / "METADATA").write_text("name: helloworld", encoding="utf-8")
 
     # We don't control the metadata. According to PEP-517, "The hook MAY also
     # create other files inside this directory, and a build frontend MUST
     # preserve".
-    (distinfo / 'FOO').write_text("bar", encoding="utf-8")
+    (distinfo / "FOO").write_text("bar", encoding="utf-8")
     subprocess.check_call(
         [
-            sys.executable, "setup.py", "bdist_wheel",
-            "-b", str(tmp_path), "--universal",
-            "--dist-info-dir", str(distinfo),
+            sys.executable,
+            "setup.py",
+            "bdist_wheel",
+            "-b",
+            str(tmp_path),
+            "--universal",
+            "--dist-info-dir",
+            str(distinfo),
         ],
     )
     with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
         with wf.open("dummy_dist-1.0.dist-info/METADATA") as fh:
-            assert fh.read() == b'name: helloworld'
-        assert 'dummy_dist-1.0.dist-info/FOO' in list(wf.namelist())
+            assert fh.read() == b"name: helloworld"
+        assert "dummy_dist-1.0.dist-info/FOO" in list(wf.namelist())
 
 
 def test_licenses_default(dummy_dist, monkeypatch, tmp_path):

--- a/tests/test_bdist_wheel.py
+++ b/tests/test_bdist_wheel.py
@@ -123,6 +123,29 @@ def test_preserve_unicode_metadata(monkeypatch, tmp_path):
     assert "UTF-8 描述 説明" in metadata
 
 
+def test_dist_info_provided(dummy_dist, monkeypatch, tmp_path):
+    monkeypatch.chdir(dummy_dist)
+    distinfo = tmp_path / "dummy_dist.dist-info"
+    distinfo.mkdir()
+    (distinfo / 'METADATA').write_text("name: helloworld", encoding="utf-8")
+
+    # We don't control the metadata. According to PEP-517, "The hook MAY also
+    # create other files inside this directory, and a build frontend MUST
+    # preserve".
+    (distinfo / 'FOO').write_text("bar", encoding="utf-8")
+    subprocess.check_call(
+        [
+            sys.executable, "setup.py", "bdist_wheel",
+            "-b", str(tmp_path), "--universal",
+            "--dist-info-dir", str(distinfo),
+        ],
+    )
+    with WheelFile("dist/dummy_dist-1.0-py2.py3-none-any.whl") as wf:
+        with wf.open("dummy_dist-1.0.dist-info/METADATA") as fh:
+            assert fh.read() == b'name: helloworld'
+        assert 'dummy_dist-1.0.dist-info/FOO' in list(wf.namelist())
+
+
 def test_licenses_default(dummy_dist, monkeypatch, tmp_path):
     monkeypatch.chdir(dummy_dist)
     subprocess.check_call(


### PR DESCRIPTION
Support passing dist-info-dir to bdist_wheel, enabling setuptools to handle prepare_metadata_for_build_wheel correctly as per PEP-517. Closes #611


I don't know what the implications of this if the metadata is wildly different - for example, within bdist_wheel there is a filename calculation - currently the metadata used for such calculations is from ``egg-info``, not from the given ``dist-info``. For my case, that was good enough, and I wasn't able to find a satisfying hook to disable ``egg-info`` calculation, and use that for ``distribution`` metadata. I would happily take advice on these.