### PR TITLE
Apply new ruff/pyupgrade rule UP032

### DIFF
--- a/src/wheel/vendored/packaging/markers.py
+++ b/src/wheel/vendored/packaging/markers.py
@@ -166,7 +166,7 @@ def _evaluate_markers(markers: MarkerList, environment: Dict[str, str]) -> bool:
 
 
 def format_full_version(info: "sys._version_info") -> str:
-    version = "{0.major}.{0.minor}.{0.micro}".format(info)
+    version = f"{info.major}.{info.minor}.{info.micro}"
     kind = info.releaselevel
     if kind != "final":
         version += kind[0] + str(info.serial)

--- a/src/wheel/vendored/packaging/tags.py
+++ b/src/wheel/vendored/packaging/tags.py
@@ -238,9 +238,7 @@ def cpython_tags(
     if use_abi3:
         for minor_version in range(python_version[1] - 1, 1, -1):
             for platform_ in platforms:
-                interpreter = "cp{version}".format(
-                    version=_version_nodot((python_version[0], minor_version))
-                )
+                interpreter = f"cp{_version_nodot((python_version[0], minor_version))}"
                 yield Tag(interpreter, "abi3", platform_)
 
 
@@ -442,9 +440,7 @@ def mac_platforms(
             compat_version = 10, minor_version
             binary_formats = _mac_binary_formats(compat_version, arch)
             for binary_format in binary_formats:
-                yield "macosx_{major}_{minor}_{binary_format}".format(
-                    major=10, minor=minor_version, binary_format=binary_format
-                )
+                yield f"macosx_10_{minor_version}_{binary_format}"
 
     if version >= (11, 0):
         # Starting with Mac OS 11, each yearly release bumps the major version
@@ -453,9 +449,7 @@ def mac_platforms(
             compat_version = major_version, 0
             binary_formats = _mac_binary_formats(compat_version, arch)
             for binary_format in binary_formats:
-                yield "macosx_{major}_{minor}_{binary_format}".format(
-                    major=major_version, minor=0, binary_format=binary_format
-                )
+                yield f"macosx_{major_version}_0_{binary_format}"
 
     if version >= (11, 0):
         # Mac OS 11 on x86_64 is compatible with binaries from previous releases.
@@ -470,20 +464,12 @@ def mac_platforms(
                 compat_version = 10, minor_version
                 binary_formats = _mac_binary_formats(compat_version, arch)
                 for binary_format in binary_formats:
-                    yield "macosx_{major}_{minor}_{binary_format}".format(
-                        major=compat_version[0],
-                        minor=compat_version[1],
-                        binary_format=binary_format,
-                    )
+                    yield f"macosx_{compat_version[0]}_{compat_version[1]}_{binary_format}"
         else:
             for minor_version in range(16, 3, -1):
                 compat_version = 10, minor_version
                 binary_format = "universal2"
-                yield "macosx_{major}_{minor}_{binary_format}".format(
-                    major=compat_version[0],
-                    minor=compat_version[1],
-                    binary_format=binary_format,
-                )
+                yield f"macosx_{compat_version[0]}_{compat_version[1]}_{binary_format}"
 
 
 def _linux_platforms(is_32bit: bool = _32_BIT_INTERPRETER) -> Iterator[str]:


### PR DESCRIPTION
	UP032 Use f-string instead of `format` call

Not sure why CI jobs don't catch this, especially after updating ruff from 0.3.5 to 0.4.3 in 0b7771e.