### PR TITLE
chore: make sure local ruff runs don't touch vendored

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,9 @@ show_missing = true
 
 [tool.ruff]
 extend-exclude = ["src/wheel/vendored"]
-lint.extend-select = [
+
+[tool.ruff.lint]
+extend-select = [
     "B",            # flake8-bugbear
     "G",            # flake8-logging-format
     "I",            # isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,6 @@ exclude = [
     "**/__pycache__",
 ]
 
-[tool.black]
-extend-exclude = '''
-^/src/wheel/vendored/
-'''
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
@@ -103,7 +98,6 @@ lint.extend-select = [
     "UP",           # pyupgrade
     "W",            # pycodestyle warnings
 ]
-
 
 # Tox (https://tox.wiki/) is a tool for running tests in multiple virtualenvs.
 # This configuration file will run the test suite on all supported python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,9 @@ omit = ["*/vendored/*"]
 [tool.coverage.report]
 show_missing = true
 
-[tool.ruff.lint]
-extend-select = [
+[tool.ruff]
+extend-exclude = ["src/wheel/vendored"]
+lint.extend-select = [
     "B",            # flake8-bugbear
     "G",            # flake8-logging-format
     "I",            # isort
@@ -102,6 +103,7 @@ extend-select = [
     "UP",           # pyupgrade
     "W",            # pycodestyle warnings
 ]
+
 
 # Tox (https://tox.wiki/) is a tool for running tests in multiple virtualenvs.
 # This configuration file will run the test suite on all supported python


### PR DESCRIPTION
It's useful to run ruff locally sometimes, like to add `--unsafe-fixes`. This ensures it doesn't format or change something it shouldn't. See https://github.com/pypa/wheel/pull/617.
