### PR TITLE
Use brackets for the default value of option arguments

### DIFF
--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -179,7 +179,7 @@ class bdist_wheel(Command):
             "plat-name=",
             "p",
             "platform name to embed in generated filenames "
-            f"(default: {get_platform(None)})",
+            f"[default: {get_platform(None)}]",
         ),
         (
             "keep-temp",
@@ -192,7 +192,7 @@ class bdist_wheel(Command):
         (
             "relative",
             None,
-            "build the archive using relative paths (default: false)",
+            "build the archive using relative paths [default: false]",
         ),
         (
             "owner=",
@@ -204,18 +204,18 @@ class bdist_wheel(Command):
             "g",
             "Group name used when creating a tar file [default: current group]",
         ),
-        ("universal", None, "make a universal wheel (default: false)"),
+        ("universal", None, "make a universal wheel [default: false]"),
         (
             "compression=",
             None,
-            "zipfile compression (one of: {}) (default: 'deflated')".format(
+            "zipfile compression (one of: {}) [default: 'deflated']".format(
                 ", ".join(supported_compressions)
             ),
         ),
         (
             "python-tag=",
             None,
-            f"Python implementation compatibility tag (default: '{python_tag()}')",
+            f"Python implementation compatibility tag [default: '{python_tag()}']",
         ),
         (
             "build-number=",
@@ -227,7 +227,7 @@ class bdist_wheel(Command):
         (
             "py-limited-api=",
             None,
-            "Python tag (cp32|cp33|cpNN) for abi3 wheel tag (default: false)",
+            "Python tag (cp32|cp33|cpNN) for abi3 wheel tag [default: false]",
         ),
     ]
 


### PR DESCRIPTION
The goal is to standardize the format of the help text printed by commands. It is not easy to choose between brackets `[]` and parentheses `()`. I went for the [docopt](http://docopt.org/) style, which is the closest to a standard I could find
> [...] and whether that argument has a default value ([default: 10]).

This change has already been applied to distutils (https://github.com/pypa/distutils/pull/262).

Fixes #616.