### PR TITLE
Improve compatibility with future versions of `setuptools`

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+**UNRELEASED**
+
+- Added a redirection from ``wheel.bdist_wheel.bdist_wheel`` to
+  ``setuptools.command.bdist_wheel.bdist_wheel`` to improve
+  compatibility with ``setuptools``' latest fixes (#638).
+  Projects are still advised to migrate away from the deprecated
+  module and import the ``setuptools``' implementation explicitly.
+
 **0.44.0 (2024-08-04)**
 
 - Canonicalized requirements in METADATA file (PR by Wim Jeantine-Glenn)

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,10 +4,11 @@ Release Notes
 **UNRELEASED**
 
 - Added a redirection from ``wheel.bdist_wheel.bdist_wheel`` to
-  ``setuptools.command.bdist_wheel.bdist_wheel`` to improve
-  compatibility with ``setuptools``' latest fixes (#638).
-  Projects are still advised to migrate away from the deprecated
-  module and import the ``setuptools``' implementation explicitly.
+  ``setuptools.command.bdist_wheel.bdist_wheel`` to improve compatibility with
+  ``setuptools``' latest fixes.
+
+  Projects are still advised to migrate away from the deprecated  module and import
+  the ``setuptools``' implementation explicitly. (PR by @abravalheri)
 
 **0.44.0 (2024-08-04)**
 

--- a/src/wheel/bdist_wheel.py
+++ b/src/wheel/bdist_wheel.py
@@ -1,6 +1,5 @@
+from typing import TYPE_CHECKING
 from warnings import warn
-
-from ._bdist_wheel import bdist_wheel as bdist_wheel
 
 warn(
     "The 'wheel' package is no longer the canonical location of the 'bdist_wheel' "
@@ -9,3 +8,19 @@ warn(
     DeprecationWarning,
     stacklevel=1,
 )
+
+if TYPE_CHECKING:
+    from ._bdist_wheel import bdist_wheel as bdist_wheel
+else:
+    try:
+        # Better integration/compatibility with setuptools:
+        # in the case new fixes or PEPs are implemented in setuptools
+        # there is no need to backport them to the deprecated code base.
+        # This is useful in the case of old packages in the ecosystem
+        # that are still used but have low maintenance.
+        from setuptools.command.bdist_wheel import bdist_wheel
+    except ImportError:
+        # Only used in the case of old setuptools versions.
+        # If the user wants to get the latest fixes/PEPs,
+        # they are encouraged to address the deprecation warning.
+        from ._bdist_wheel import bdist_wheel as bdist_wheel


### PR DESCRIPTION
While working on [the implementation of PEP 643](https://github.com/pypa/setuptools/pull/4698), I realised that if we implement a new version of metadata in `setuptools`, once the current version of `wheel.bdist_wheel` runs in deprecated scenarios, it will produce invalid metadata.

We can also expand this reasoning to other fixes and/or PEP implementations. A recent example was the fix for https://github.com/pypa/setuptools/issues/1825, proposed in https://github.com/pypa/setuptools/pull/4647, which caused some trouble and required the implementation of a very intrusive workaround: https://github.com/pypa/setuptools/pull/4684#issuecomment-2431247361.

I was thinking if there was any way we could address that while maintaining as much as possible a backwards compatible API (in both setuptools and wheel) so that we minimise the amount of disruption in the community while going forward[^1]. So I came up with the idea for this PR.

Please let me know your thoughts on the subject.

[^1]: Unfortunately there are many packages in the ecosystem that are widespread but have low maintenance. It is possible that a small amount of those will never address the deprecation warning...