### PR TITLE
Check for empty description when converting metadata

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -2,7 +2,9 @@ Release Notes
 =============
 
 **UNRELEASED**
-- Fixed an exception when calling the `convert` command with an empty description field
+
+- Fixed an exception when calling the ``convert`` command with an empty description
+  field
 
 **0.45.1 (2024-11-23)**
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,9 @@
 Release Notes
 =============
 
+**UNRELEASED**
+- Fixed an exception when calling the `convert` command with an empty description field
+
 **0.45.1 (2024-11-23)**
 
 - Fixed pure Python wheels converted from eggs and wininst files having the ABI tag in

--- a/src/wheel/cli/convert.py
+++ b/src/wheel/cli/convert.py
@@ -82,6 +82,7 @@ def convert_pkg_info(pkginfo: str, metadata: Message):
                 )
             else:
                 value = "\n"
+
             metadata.set_payload(value)
         elif key_lower == "home-page":
             metadata.add_header("Project-URL", f"Homepage, {value}")

--- a/src/wheel/cli/convert.py
+++ b/src/wheel/cli/convert.py
@@ -72,7 +72,10 @@ def convert_pkg_info(pkginfo: str, metadata: Message):
 
         if key_lower == "description":
             description_lines = value.splitlines()
-            value = "\n".join(
+            if len(description_lines) == 0:
+                value = '\n'
+            else:
+                value = "\n".join(
                 (
                     description_lines[0].lstrip(),
                     dedent("\n".join(description_lines[1:])),

--- a/src/wheel/cli/convert.py
+++ b/src/wheel/cli/convert.py
@@ -72,9 +72,7 @@ def convert_pkg_info(pkginfo: str, metadata: Message):
 
         if key_lower == "description":
             description_lines = value.splitlines()
-            if len(description_lines) == 0:
-                value = "\n"
-            else:
+            if description_lines:
                 value = "\n".join(
                     (
                         description_lines[0].lstrip(),
@@ -82,6 +80,8 @@ def convert_pkg_info(pkginfo: str, metadata: Message):
                         "\n",
                     )
                 )
+            else:
+                value = "\n"
             metadata.set_payload(value)
         elif key_lower == "home-page":
             metadata.add_header("Project-URL", f"Homepage, {value}")

--- a/src/wheel/cli/convert.py
+++ b/src/wheel/cli/convert.py
@@ -73,15 +73,15 @@ def convert_pkg_info(pkginfo: str, metadata: Message):
         if key_lower == "description":
             description_lines = value.splitlines()
             if len(description_lines) == 0:
-                value = '\n'
+                value = "\n"
             else:
                 value = "\n".join(
-                (
-                    description_lines[0].lstrip(),
-                    dedent("\n".join(description_lines[1:])),
-                    "\n",
+                    (
+                        description_lines[0].lstrip(),
+                        dedent("\n".join(description_lines[1:])),
+                        "\n",
+                    )
                 )
-            )
             metadata.set_payload(value)
         elif key_lower == "home-page":
             metadata.add_header("Project-URL", f"Homepage, {value}")

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -264,9 +264,10 @@ def test_convert_bdist_wininst(
 
     assert capsys.readouterr().out == f"{bdist_wininst_path}...OK\n"
 
+
 def test_convert_pkg_info_with_empty_description():
     # Regression test for https://github.com/pypa/wheel/issues/645
-    pkginfo =  """\
+    pkginfo = """\
 Metadata-Version: 2.1
 Name: Sampledist
 Version: 1.0.0
@@ -275,11 +276,12 @@ Download-URL: https://example.com/sampledist
 Description:"""
     message = Message()
     convert_pkg_info(pkginfo, message)
-    assert message.get_all('Name') == ['Sampledist']
-    assert message.get_payload() == '\n'
+    assert message.get_all("Name") == ["Sampledist"]
+    assert message.get_payload() == "\n"
+
 
 def test_convert_pkg_info_with_one_line_description():
-    pkginfo =  """\
+    pkginfo = """\
 Metadata-Version: 2.1
 Name: Sampledist
 Version: 1.0.0
@@ -288,5 +290,5 @@ Download-URL: https://example.com/sampledist
 Description:    My cool package"""
     message = Message()
     convert_pkg_info(pkginfo, message)
-    assert message.get_all('Name') == ['Sampledist']
-    assert message.get_payload() == 'My cool package\n\n\n'
+    assert message.get_all("Name") == ["Sampledist"]
+    assert message.get_payload() == "My cool package\n\n\n"

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os.path
 import zipfile
+from email.message import Message
 from pathlib import Path
 from textwrap import dedent
 
@@ -10,7 +11,7 @@ from _pytest.fixtures import SubRequest
 from pytest import CaptureFixture, TempPathFactory
 
 import wheel
-from wheel.cli.convert import convert, egg_filename_re
+from wheel.cli.convert import convert, convert_pkg_info, egg_filename_re
 from wheel.wheelfile import WheelFile
 
 PKG_INFO = """\
@@ -262,3 +263,30 @@ def test_convert_bdist_wininst(
         assert wf.read("sampledist-1.0.0.dist-info/entry_points.txt") == b""
 
     assert capsys.readouterr().out == f"{bdist_wininst_path}...OK\n"
+
+def test_convert_pkg_info_with_empty_description():
+    # Regression test for https://github.com/pypa/wheel/issues/645
+    pkginfo =  """\
+Metadata-Version: 2.1
+Name: Sampledist
+Version: 1.0.0
+Home-page: https://example.com
+Download-URL: https://example.com/sampledist
+Description:"""
+    message = Message()
+    convert_pkg_info(pkginfo, message)
+    assert message.get_all('Name') == ['Sampledist']
+    assert message.get_payload() == '\n'
+
+def test_convert_pkg_info_with_one_line_description():
+    pkginfo =  """\
+Metadata-Version: 2.1
+Name: Sampledist
+Version: 1.0.0
+Home-page: https://example.com
+Download-URL: https://example.com/sampledist
+Description:    My cool package"""
+    message = Message()
+    convert_pkg_info(pkginfo, message)
+    assert message.get_all('Name') == ['Sampledist']
+    assert message.get_payload() == 'My cool package\n\n\n'


### PR DESCRIPTION
To prevent an exception, check for an empty description Fixes: #645

Test plan: Run the unit tests without the fix -> Fails with an exception. Passes after the fix