### PR TITLE
Fix issue link in 0.46.1 release note

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,7 +4,7 @@ Release Notes
 **0.46.1 (2025-04-08)**
 
 - Temporarily restored the ``wheel.macosx_libfile`` module
-  (`#659 <https://github.com/pypa/wheel/issues/665960>`_)
+  (`#659 <https://github.com/pypa/wheel/issues/659>`_)
 
 **0.46.0 (2025-04-03)**
 


### PR DESCRIPTION
Link to the issue about breakage on MacOS in 0.46.0 release is broken, which seems a typo. It's confusing to be brought to a 404 page when reading through the release note.

Fixes: 98617630542d ("Restored the wheel.macosx_libfile module for setuptools")