### PR TITLE
BUG: fix PY_LIMITED_API_PATTERN regexp compatibility with Python 3.10 and newer

### DIFF
--- a/src/wheel/_bdist_wheel.py
+++ b/src/wheel/_bdist_wheel.py
@@ -68,7 +68,7 @@ def safe_version(version: str) -> str:
 
 setuptools_major_version = int(setuptools.__version__.split(".")[0])
 
-PY_LIMITED_API_PATTERN = r"cp3\d"
+PY_LIMITED_API_PATTERN = r"cp3\d+"
 
 
 def _is_32bit_interpreter() -> bool:


### PR DESCRIPTION
This regular expression implicitly assumes that the minor version of Python 3 is single-digit. Fixes it.