### PR TITLE
Fix documentation: grammar, typos, formatting, and links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This is a command line tool for manipulating Python wheel files, as defined in
 * Repack wheel archives
 * Add or remove tags in existing wheel archives
 
-.. _PEP 427: https://www.python.org/dev/peps/pep-0427/
+.. _PEP 427: https://peps.python.org/pep-0427/
 
 Historical note
 ---------------

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -8,7 +8,7 @@ Pull Requests
 - Provide a good description of what you're doing and why.
 - Provide tests that cover your changes and try to run the tests locally first.
 
-**Example**. Assuming you set up GitHub account, forked wheel repository from
+**Example**. Assuming you set up a GitHub account, forked the wheel repository from
 https://github.com/pypa/wheel to your own page via web interface, and your
 fork is located at https://github.com/yourname/wheel
 
@@ -23,7 +23,7 @@ fork is located at https://github.com/yourname/wheel
   $ git commit
 
 You may reference relevant issues in commit messages (like #1259) to
-make GitHub link issues and commits together, and with phrase like
+make GitHub link issues and commits together, and with a phrase like
 "fixes #1259" you can even close relevant issues automatically. Now
 push the changes to your fork::
 
@@ -54,7 +54,7 @@ To run the tests via tox against all matching interpreters::
 
 To run the tests via tox against a specific environment::
 
-  $ tox -e py35
+  $ tox -e py39
 
 Alternatively, you can run the tests via pytest using your default interpreter::
 
@@ -92,5 +92,5 @@ To make a new release:
 #. Create a new git tag matching the version exactly
 #. Push the new tag to GitHub
 
-Pushing a new tag to GitHub will trigger the publish workflow which package the
+Pushing a new tag to GitHub will trigger the publish workflow which will package the
 project and publish the resulting artifacts to PyPI.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,17 +6,7 @@ wheel
 User IRC: #pypa |
 Dev IRC: #pypa-dev
 
-This library is the reference implementation of the Python wheel packaging
-standard, as defined in `PEP 427`_.
-
-It has two different roles:
-
-#. A setuptools_ extension for building wheels that provides the
-   ``bdist_wheel`` setuptools command
-#. A command line tool for working with wheel files
-
-.. _PEP 427: https://www.python.org/dev/peps/pep-0427/
-.. _setuptools: https://pypi.org/project/setuptools/
+This library primarily serves as a command line tool for working with wheel files.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -15,7 +15,7 @@ can typically find the wheel package under one of the following package names:
 * python3-wheel
 
 .. _pip: https://pip.pypa.io/en/stable/
-.. _installation instructions: https://pip.pypa.io/en/stable/installing/
+.. _installation instructions: https://pip.pypa.io/en/stable/installation/
 
 Python and OS Compatibility
 ---------------------------

--- a/docs/manpages/wheel.rst
+++ b/docs/manpages/wheel.rst
@@ -43,4 +43,4 @@ Options
   -h, --help            show this help message and exit
 
 
-.. _`PEP 427`: https://www.python.org/dev/peps/pep-0427/
+.. _`PEP 427`: https://peps.python.org/pep-0427/

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -47,7 +47,7 @@ Release Notes
   ``setuptools.command.bdist_wheel.bdist_wheel`` to improve compatibility with
   ``setuptools``' latest fixes.
 
-  Projects are still advised to migrate away from the deprecated  module and import
+  Projects are still advised to migrate away from the deprecated module and import
   the ``setuptools``' implementation explicitly. (PR by @abravalheri)
 
 **0.44.0 (2024-08-04)**
@@ -127,7 +127,7 @@ Release Notes
 **0.38.1 (2022-11-04)**
 
 - Removed install dependency on setuptools
-- The future-proof fix in 0.36.0 for converting PyPy's SOABI into a abi tag was
+- The future-proof fix in 0.36.0 for converting PyPy's SOABI into an ABI tag was
   faulty. Fixed so that future changes in the SOABI will not change the tag.
 
 **0.38.0 (2022-10-21)**
@@ -175,7 +175,7 @@ Release Notes
 - Updated vendored ``packaging`` library to v20.7
 - Switched to always using LF as line separator when generating ``WHEEL`` files
   (on Windows, CRLF was being used instead)
-- The ABI tag is taken from  the sysconfig SOABI value. On PyPy the SOABI value
+- The ABI tag is taken from the sysconfig SOABI value. On PyPy the SOABI value
   is ``pypy37-pp73`` which is not compliant with PEP 3149, as it should have
   both the API tag and the platform tag. This change future-proofs any change
   in PyPy's SOABI tag to make sure only the ABI tag is used by wheel.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -14,7 +14,7 @@ section to your ``setup.cfg``::
     [bdist_wheel]
     universal = 1
 
-To convert an ``.egg`` or file to a wheel::
+To convert an ``.egg`` file or directory to a wheel::
 
     wheel convert youreggfile.egg
 

--- a/docs/reference/wheel_convert.rst
+++ b/docs/reference/wheel_convert.rst
@@ -17,8 +17,8 @@ installers (``.exe``; made with ``bdist_wininst``) into wheels.
 
 Egg names must match the standard format:
 
-* ``<project>-<version>-pyX.Y`` for pure Python wheels
-* ``<project>-<version>-pyX.Y-<arch>`` for binary wheels
+* ``<project>-<version>-pyX.Y`` for pure Python eggs
+* ``<project>-<version>-pyX.Y-<arch>`` for binary eggs
 
 
 Options

--- a/docs/reference/wheel_pack.rst
+++ b/docs/reference/wheel_pack.rst
@@ -28,7 +28,7 @@ Options
 
 .. option:: --build-number <tag>
 
-    Override the build tag in the new wheel file name
+    Override the build tag in the new wheel file name.
 
 Examples
 --------

--- a/docs/reference/wheel_tags.rst
+++ b/docs/reference/wheel_tags.rst
@@ -12,8 +12,8 @@ Description
 -----------
 
 Make a new wheel with given tags from an existing wheel. Any tags left
-unspecified will remain the same. Multiple tags are separated by a "." Starting
-with a "+" will append to the existing tags.  Starting with a "-" will remove a
+unspecified will remain the same. Multiple tags are separated by a ".". Starting
+with a "+" will append to the existing tags. Starting with a "-" will remove a
 tag. Be sure to use the equals syntax on the shell so that it does not get
 parsed as an extra option, such as ``--python-tag=-py2``. The original file
 will remain unless ``--remove`` is given. The output filename(s) will be
@@ -29,12 +29,12 @@ Options
 
 .. option:: --python-tag=TAG
 
-    Override the python tag (prepend with "+" to append, "-" to remove).
+    Override the Python tag (prepend with "+" to append, "-" to remove).
     Multiple tags can be separated with a dot.
 
 .. option:: --abi-tag=TAG
 
-    Override the abi tag (prepend with "+" to append, "-" to remove).
+    Override the ABI tag (prepend with "+" to append, "-" to remove).
     Multiple tags can be separated with a dot.
 
 .. option:: --platform-tag=TAG

--- a/docs/story.rst
+++ b/docs/story.rst
@@ -21,7 +21,7 @@ It was a lot of work. The package is worse off than before, and it can’t
 be built or installed without patching the Python source code itself.
 
 It was about that time that distutils-sig had a discussion about the
-need to include a generated ``setup.cfg`` from ``setup.cfg`` because
+need to include a generated ``setup.py`` from ``setup.cfg`` because
 ``setup.cfg`` wasn’t static enough. Wait, what?
 
 Of course there is a different way to massively simplify the install


### PR DESCRIPTION
Should both roles remain documented?
https://github.com/pypa/wheel/blob/8b6fa740a7101edacb42b0f8e83a1b659ff61033/docs/index.rst#L12-L19

The README has been updated so the documentation seems inconsistent:
https://github.com/pypa/wheel/blob/8b6fa740a7101edacb42b0f8e83a1b659ff61033/README.rst#L14-L20