### PR TITLE
`__package__` → `__spec__.parent`

### DIFF
--- a/src/wheel/__main__.py
+++ b/src/wheel/__main__.py
@@ -9,7 +9,7 @@ from typing import NoReturn
 
 
 def main() -> NoReturn:  # needed for console script
-    if __package__ == "":
+    if __spec__.parent == "":
         # To be able to run 'python wheel-0.9.whl/wheel':
         import os.path
 


### PR DESCRIPTION
Removed deprecated `__package__`, scheduled for [removal in Python 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__).