### PR TITLE
chore: log_level is better than log_cli_level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ filterwarnings = [
     "error",
     "ignore::Warning:_pytest.*",
 ]
-log_cli_level = "info"
+log_level = "INFO"
 testpaths = ["test"]
 
 [tool.coverage.run]


### PR DESCRIPTION
I probably added this, someone eventually pointed out that `log_level` exists and is more appropriate than `log_cli_level`. Also using upper case `INFO`, as the schema for pytest requires upper case here.