### PR TITLE
fix(wheelfile): resolve .dist-info path case-insensitively when reading wheels

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,6 +3,10 @@ Release Notes
 
 **UNRELEASED**
 
+- Fixed ``WheelFile`` raising ``Missing RECORD file`` when the wheel filename
+  contains uppercase characters (e.g. ``Django-3.2.5.whl``) but the
+  ``.dist-info`` directory inside uses normalized lowercase naming
+  (`#411 <https://github.com/pypa/wheel/issues/411>`_)
 - Added the ``wheel info`` subcommand to display metadata about wheel files without
   unpacking them (`#639 <https://github.com/pypa/wheel/issues/639>`_)
 

--- a/src/wheel/wheelfile.py
+++ b/src/wheel/wheelfile.py
@@ -82,11 +82,6 @@ class WheelFile(ZipFile):
         self._file_hashes: dict[str, tuple[None, None] | tuple[int, bytes]] = {}
         self._file_sizes = {}
         if mode == "r":
-            # Ignore RECORD and any embedded wheel signatures
-            self._file_hashes[self.record_path] = None, None
-            self._file_hashes[self.record_path + ".jws"] = None, None
-            self._file_hashes[self.record_path + ".p7s"] = None, None
-
             # The .dist-info directory inside the wheel may use normalized
             # (lowercase) naming even when the filename does not. Resolve the
             # actual path case-insensitively.
@@ -96,11 +91,12 @@ class WheelFile(ZipFile):
                     if name.lower() == lowered:
                         self.dist_info_path = name.rsplit("/RECORD", 1)[0]
                         self.record_path = name
-                        # Update hash skip entries to use the resolved path
-                        self._file_hashes[name] = None, None
-                        self._file_hashes[name + ".jws"] = None, None
-                        self._file_hashes[name + ".p7s"] = None, None
                         break
+
+            # Ignore RECORD and any embedded wheel signatures
+            self._file_hashes[self.record_path] = None, None
+            self._file_hashes[self.record_path + ".jws"] = None, None
+            self._file_hashes[self.record_path + ".p7s"] = None, None
 
             # Fill in the expected hashes by reading them from RECORD
             try:

--- a/src/wheel/wheelfile.py
+++ b/src/wheel/wheelfile.py
@@ -87,6 +87,21 @@ class WheelFile(ZipFile):
             self._file_hashes[self.record_path + ".jws"] = None, None
             self._file_hashes[self.record_path + ".p7s"] = None, None
 
+            # The .dist-info directory inside the wheel may use normalized
+            # (lowercase) naming even when the filename does not. Resolve the
+            # actual path case-insensitively.
+            if self.record_path not in self.namelist():
+                lowered = self.dist_info_path.lower() + "/RECORD"
+                for name in self.namelist():
+                    if name.lower() == lowered:
+                        self.dist_info_path = name.rsplit("/RECORD", 1)[0]
+                        self.record_path = name
+                        # Update hash skip entries to use the resolved path
+                        self._file_hashes[name] = None, None
+                        self._file_hashes[name + ".jws"] = None, None
+                        self._file_hashes[name + ".p7s"] = None, None
+                        break
+
             # Fill in the expected hashes by reading them from RECORD
             try:
                 record = self.open(self.record_path)

--- a/src/wheel/wheelfile.py
+++ b/src/wheel/wheelfile.py
@@ -91,7 +91,7 @@ class WheelFile(ZipFile):
             # (lowercase) naming even when the filename does not. Resolve the
             # actual path case-insensitively.
             if self.record_path not in self.namelist():
-                lowered = self.dist_info_path.lower() + "/RECORD"
+                lowered = self.dist_info_path.lower() + "/record"
                 for name in self.namelist():
                     if name.lower() == lowered:
                         self.dist_info_path = name.rsplit("/RECORD", 1)[0]

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -54,6 +54,34 @@ def test_missing_record(wheel_path: Path) -> None:
     exc.match("^Missing test-1.0.dist-info/RECORD file$")
 
 
+def test_mixed_case_dist_info(tmp_path: Path) -> None:
+    """Regression test: wheel filename has uppercase but .dist-info dir is lowercase.
+
+    A wheel named ``Django-3.2.5.whl`` may contain ``django-3.2.5.dist-info/``
+    inside (normalized). WheelFile should find RECORD case-insensitively.
+    See `#411 <https://github.com/pypa/wheel/issues/411>`_.
+    """
+    wheel_path = tmp_path / "MixedCase-1.0-py3-none-any.whl"
+    with ZipFile(wheel_path, "w", ZIP_DEFLATED) as zf:
+        zf.writestr("mixedcase/__init__.py", "")
+        # Use lowercase dist-info (as pip/build tools produce)
+        zf.writestr("mixedcase-1.0.dist-info/WHEEL", "Wheel-Version: 1.0\n")
+        zf.writestr(
+            "mixedcase-1.0.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: MixedCase\nVersion: 1.0\n",
+        )
+        zf.writestr(
+            "mixedcase-1.0.dist-info/RECORD",
+            "mixedcase/__init__.py,,\n",
+        )
+
+    # Should not raise — this is the fix
+    wf = WheelFile(wheel_path)
+    assert wf.dist_info_path == "mixedcase-1.0.dist-info"
+    assert wf.record_path == "mixedcase-1.0.dist-info/RECORD"
+    wf.close()
+
+
 def test_unsupported_hash_algorithm(wheel_path: Path) -> None:
     with ZipFile(wheel_path, "w") as zf:
         zf.writestr("hello/héllö.py", 'print("Héllö, w0rld!")\n')

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -76,10 +76,9 @@ def test_mixed_case_dist_info(tmp_path: Path) -> None:
         )
 
     # Should not raise — this is the fix
-    wf = WheelFile(wheel_path)
-    assert wf.dist_info_path == "mixedcase-1.0.dist-info"
-    assert wf.record_path == "mixedcase-1.0.dist-info/RECORD"
-    wf.close()
+    with WheelFile(wheel_path) as wf:
+        assert wf.dist_info_path == "mixedcase-1.0.dist-info"
+        assert wf.record_path == "mixedcase-1.0.dist-info/RECORD"
 
 
 def test_unsupported_hash_algorithm(wheel_path: Path) -> None:


### PR DESCRIPTION
## Summary

A wheel filename may contain non-lowercase characters (e.g.`Django-3.2.5.whl`) while the `.dist-info` directory inside uses normalized lowercase naming (`django-3.2.5.dist-info/`). `WheelFile` previously derived `dist_info_path` strictly from the filename, causing a `Missing RECORD file` error on open.

Fixes #411

## Details

When opening a wheel in read mode, if the expected `.dist-info/RECORD` path is not found in the zip namelist, search for a case-insensitive match and use the resolved path for all subsequent operations (RECORD parsing, hash skipping).

The fix is confined to `WheelFile.__init__` and only activates when the exact-path lookup fails, so there is no performance impact on wheels that already match.