### PR TITLE
Preserve compatible metadata versions in convert

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,6 +3,8 @@ Release Notes
 
 **0.47.0 (2026-04-22)**
 
+- Fixed ``wheel convert`` unnecessarily upgrading compatible core metadata versions
+  (`#643 <https://github.com/pypa/wheel/issues/643>`_)
 - Added the ``wheel info`` subcommand to display metadata about wheel files without
   unpacking them (`#639 <https://github.com/pypa/wheel/issues/639>`_)
 - Fixed ``WheelFile`` raising ``Missing RECORD file`` when the wheel filename contains

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,14 +3,14 @@ Release Notes
 
 **0.47.0 (2026-04-22)**
 
-- Fixed ``wheel convert`` unnecessarily upgrading compatible core metadata versions
-  (`#643 <https://github.com/pypa/wheel/issues/643>`_)
 - Added the ``wheel info`` subcommand to display metadata about wheel files without
   unpacking them (`#639 <https://github.com/pypa/wheel/issues/639>`_)
 - Fixed ``WheelFile`` raising ``Missing RECORD file`` when the wheel filename contains
   uppercase characters (e.g. ``Django-3.2.5.whl``) but the ``.dist-info`` directory
   inside uses normalized lowercase naming
   (`#411 <https://github.com/pypa/wheel/issues/411>`_)
+- Fixed ``wheel convert`` unnecessarily upgrading compatible core metadata versions
+  (`#643 <https://github.com/pypa/wheel/issues/643>`_)
 
 **0.46.3 (2026-01-22)**
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+**UNRELEASED**
+
+- Fixed ``wheel convert`` unnecessarily upgrading compatible core metadata versions
+  (`#643 <https://github.com/pypa/wheel/issues/643>`_)
+
 **0.47.0 (2026-04-22)**
 
 - Added the ``wheel info`` subcommand to display metadata about wheel files without
@@ -9,8 +14,6 @@ Release Notes
   uppercase characters (e.g. ``Django-3.2.5.whl``) but the ``.dist-info`` directory
   inside uses normalized lowercase naming
   (`#411 <https://github.com/pypa/wheel/issues/411>`_)
-- Fixed ``wheel convert`` unnecessarily upgrading compatible core metadata versions
-  (`#643 <https://github.com/pypa/wheel/issues/643>`_)
 
 **0.46.3 (2026-01-22)**
 

--- a/src/wheel/_commands/convert.py
+++ b/src/wheel/_commands/convert.py
@@ -44,6 +44,7 @@ serialization_policy = EmailPolicy(
     max_line_length=0,
 )
 GENERATOR = f"wheel {__version__}"
+LOWEST_CONVERTED_METADATA_VERSION = (1, 2)
 
 
 def convert_requires(requires: str, metadata: Message) -> None:
@@ -66,6 +67,7 @@ def convert_requires(requires: str, metadata: Message) -> None:
 
 def convert_pkg_info(pkginfo: str, metadata: Message) -> None:
     parsed_message = Parser().parsestr(pkginfo)
+    metadata_version = parsed_message.get("Metadata-Version", "1.0")
     for key, value in parsed_message.items():
         key_lower = key.lower()
         if value == "UNKNOWN":
@@ -92,7 +94,23 @@ def convert_pkg_info(pkginfo: str, metadata: Message) -> None:
         else:
             metadata.add_header(key, value)
 
-    metadata.replace_header("Metadata-Version", "2.4")
+    metadata.replace_header(
+        "Metadata-Version",
+        _compatible_metadata_version(metadata_version),
+    )
+
+
+def _compatible_metadata_version(metadata_version: str) -> str:
+    try:
+        major_str, minor_str = metadata_version.split(".", 1)
+        major_minor = (int(major_str), int(minor_str))
+    except ValueError:
+        return "1.2"
+
+    if major_minor < LOWEST_CONVERTED_METADATA_VERSION:
+        return "1.2"
+
+    return metadata_version
 
 
 def normalize(name: str) -> str:

--- a/src/wheel/_commands/convert.py
+++ b/src/wheel/_commands/convert.py
@@ -44,7 +44,6 @@ serialization_policy = EmailPolicy(
     max_line_length=0,
 )
 GENERATOR = f"wheel {__version__}"
-LOWEST_CONVERTED_METADATA_VERSION = (1, 2)
 
 
 def convert_requires(requires: str, metadata: Message) -> None:
@@ -107,7 +106,7 @@ def _compatible_metadata_version(metadata_version: str) -> str:
     except ValueError:
         return "1.2"
 
-    if major_minor < LOWEST_CONVERTED_METADATA_VERSION:
+    if major_minor < (1, 2):
         return "1.2"
 
     return metadata_version

--- a/tests/commands/test_convert.py
+++ b/tests/commands/test_convert.py
@@ -301,15 +301,3 @@ Home-page: https://example.com
     message = Message()
     convert_pkg_info(pkginfo, message)
     assert message["Metadata-Version"] == "1.2"
-
-
-def test_convert_pkg_info_preserves_compatible_metadata_version() -> None:
-    pkginfo = """\
-Metadata-Version: 2.1
-Name: Sampledist
-Version: 1.0.0
-Home-page: https://example.com
-"""
-    message = Message()
-    convert_pkg_info(pkginfo, message)
-    assert message["Metadata-Version"] == "2.1"

--- a/tests/commands/test_convert.py
+++ b/tests/commands/test_convert.py
@@ -42,7 +42,7 @@ six
 """
 
 EXPECTED_METADATA = """\
-Metadata-Version: 2.4
+Metadata-Version: 2.1
 Name: Sampledist
 Version: 1.0.0
 Author: Alex Grönholm
@@ -289,3 +289,27 @@ Description:    My cool package"""
     convert_pkg_info(pkginfo, message)
     assert message.get_all("Name") == ["Sampledist"]
     assert message.get_payload() == "My cool package\n\n\n"
+
+
+def test_convert_pkg_info_uses_lowest_compatible_metadata_version() -> None:
+    pkginfo = """\
+Metadata-Version: 1.1
+Name: Sampledist
+Version: 1.0.0
+Home-page: https://example.com
+"""
+    message = Message()
+    convert_pkg_info(pkginfo, message)
+    assert message["Metadata-Version"] == "1.2"
+
+
+def test_convert_pkg_info_preserves_compatible_metadata_version() -> None:
+    pkginfo = """\
+Metadata-Version: 2.1
+Name: Sampledist
+Version: 1.0.0
+Home-page: https://example.com
+"""
+    message = Message()
+    convert_pkg_info(pkginfo, message)
+    assert message["Metadata-Version"] == "2.1"


### PR DESCRIPTION
## Summary

Preserve the source metadata version during `wheel convert` when it is already compatible, instead of always rewriting converted metadata to `2.4`.

Closes #643.

## Problem

On current `main`, `wheel convert` rewrites converted `PKG-INFO` metadata to `Metadata-Version: 2.4` unconditionally.

That means converting an egg with `Metadata-Version: 2.1` produces a wheel whose `METADATA` advertises `2.4`, even when the converted fields only require the older format. The issue report shows that this breaks downstream repositories such as Artifactory instances that still reject metadata newer than `2.3`.

The packaging spec also says build tools may emit the lowest metadata version that supports the fields they write.

## Solution

- keep the source metadata version when it is already high enough for the converted fields
- only bump older source metadata to `1.2`, which is the minimum version needed for the generated `Requires-Dist` and `Project-URL` fields
- update the convert expectations and add direct regression tests for both `1.1 -> 1.2` and `2.1 -> 2.1`

## Verification

- `.venv/bin/pytest -q`
- `.venv/bin/pytest tests/commands/test_convert.py -q`
- `.venv/bin/ruff check src/wheel/_commands/convert.py tests/commands/test_convert.py`
- `PYTHONPATH=src .venv/bin/python - <<'PY' ...` probe confirming `1.1 -> 1.2` and `2.1 -> 2.1`
