### PR TITLE
Strip ZIP64 extra field when retagging wheels (#692)

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,15 +3,15 @@ Release Notes
 
 **UNRELEASED**
 
-- Fixed ``wheel tags`` producing invalid archives when retagging wheels whose
-  entries use ZIP64, by dropping the central-directory ZIP64 extra field that is
-  not valid in a local file header
-  (`#692 <https://github.com/pypa/wheel/issues/692>`_)
 - Added a ``--local-version`` option to ``wheel pack`` to add, replace, or remove a
   PEP 440 local version identifier from a wheel
   (`#570 <https://github.com/pypa/wheel/issues/570>`_)
 - Fixed ``wheel convert`` unnecessarily upgrading compatible core metadata versions
   (`#643 <https://github.com/pypa/wheel/issues/643>`_)
+- Fixed ``wheel tags`` producing invalid archives when retagging wheels whose
+  entries use ZIP64, by dropping the central-directory ZIP64 extra field that is
+  not valid in a local file header
+  (`#692 <https://github.com/pypa/wheel/issues/692>`_)
 
 **0.47.0 (2026-04-22)**
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -3,6 +3,10 @@ Release Notes
 
 **UNRELEASED**
 
+- Fixed ``wheel tags`` producing invalid archives when retagging wheels whose
+  entries use ZIP64, by dropping the central-directory ZIP64 extra field that is
+  not valid in a local file header
+  (`#692 <https://github.com/pypa/wheel/issues/692>`_)
 - Added a ``--local-version`` option to ``wheel pack`` to add, replace, or remove a
   PEP 440 local version identifier from a wheel
   (`#570 <https://github.com/pypa/wheel/issues/570>`_)

--- a/src/wheel/_commands/tags.py
+++ b/src/wheel/_commands/tags.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import email.policy
 import itertools
 import os
+import struct
 from collections.abc import Iterable
 from email.parser import BytesParser
 
 from ..wheelfile import WheelFile
+
+# Header ID of the ZIP64 extended information extra field.
+_ZIP64_EXTRA_ID = 0x0001
 
 
 def _compute_tags(original_tags: Iterable[str], new_tags: str | None) -> set[str]:
@@ -21,6 +25,26 @@ def _compute_tags(original_tags: Iterable[str], new_tags: str | None) -> set[str
         return set(original_tags) - set(new_tags[1:].split("."))
 
     return set(new_tags.split("."))
+
+
+def _strip_zip64_extra(extra: bytes) -> bytes:
+    """Drop the ZIP64 extra field copied from a central-directory entry.
+
+    The ZIP64 field encodes the local-header offset, which is meaningful only
+    in the central directory. Keeping it in a local header produces an invalid
+    archive; removing it lets zipfile regenerate a correct field when needed.
+    """
+    kept: list[bytes] = []
+    while len(extra) >= 4:
+        field_id, field_size = struct.unpack("<HH", extra[:4])
+        field_end = 4 + field_size
+        if field_id != _ZIP64_EXTRA_ID:
+            kept.append(extra[:field_end])
+
+        extra = extra[field_end:]
+
+    kept.append(extra)
+    return b"".join(kept)
 
 
 def tags(
@@ -127,6 +151,7 @@ def tags(
             for item in fin.infolist():
                 if item.is_dir():
                     continue
+                item.extra = _strip_zip64_extra(item.extra)
                 if item.filename == f.dist_info_path + "/RECORD":
                     continue
                 if item.filename == f.dist_info_path + "/WHEEL":

--- a/tests/commands/test_tags.py
+++ b/tests/commands/test_tags.py
@@ -5,7 +5,7 @@ import struct
 import zipfile
 from pathlib import Path
 from subprocess import CalledProcessError
-from zipfile import ZIP_STORED, ZipFile
+from zipfile import ZIP_STORED, ZipFile, ZipInfo
 
 import pytest
 
@@ -244,11 +244,18 @@ def test_retag_does_not_leak_zip64_into_local_headers(
     # headers that strict parsers reject (#692). Force ZIP64 on small files.
     monkeypatch.setattr(zipfile, "ZIP64_LIMIT", 512)
 
+    # A non-ZIP64 extra field whose payload embeds the ZIP64 header id, to
+    # confirm the fix walks the extra-field structure rather than blindly
+    # stripping the 0x0001 byte pattern wherever it appears.
+    custom_extra = b"\xca\xfe\x05\x00\x01\x00\x99\x99\x99"
+    init_info = ZipInfo("test/__init__.py")
+    init_info.extra = custom_extra
+
     wheelpath = tmp_path / "test-1.0-py3-none-any.whl"
     with WheelFile(wheelpath, "w", compression=ZIP_STORED) as wheel_file:
         wheel_file.writestr("test/padding1", b"x" * 400)
         wheel_file.writestr("test/padding2", b"x" * 400)
-        wheel_file.writestr("test/__init__.py", b"")
+        wheel_file.writestr(init_info, b"")
         wheel_file.writestr(
             "test-1.0.dist-info/WHEEL",
             "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
@@ -260,9 +267,7 @@ def test_retag_does_not_leak_zip64_into_local_headers(
 
     # Sanity check: the source really has ZIP64 entries.
     with ZipFile(wheelpath) as source:
-        assert any(
-            item.extra[:2] == b"\x01\x00" for item in source.infolist()
-        )
+        assert any(item.extra[:2] == b"\x01\x00" for item in source.infolist())
 
     newname = tags(str(wheelpath), platform_tags="linux_x86_64")
     output_file = wheelpath.parent / newname
@@ -276,5 +281,9 @@ def test_retag_does_not_leak_zip64_into_local_headers(
             assert extra[:2] != b"\x01\x00", (
                 f"{item.filename} local header carries a ZIP64 extra field"
             )
+            if item.filename == "test/__init__.py":
+                assert extra == custom_extra, (
+                    "non-ZIP64 extra field was not preserved on retag"
+                )
 
     output_file.unlink()

--- a/tests/commands/test_tags.py
+++ b/tests/commands/test_tags.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import shutil
+import struct
+import zipfile
 from pathlib import Path
 from subprocess import CalledProcessError
-from zipfile import ZipFile
+from zipfile import ZIP_STORED, ZipFile
 
 import pytest
 
+from wheel._commands.tags import tags
 from wheel.wheelfile import WheelFile
 
 from .util import run_command
@@ -227,6 +230,51 @@ def test_permission_bits(wheelpath: Path) -> None:
             inf_attr = member_info.external_attr
             assert out_attr == inf_attr, (
                 f"{member} 0x{out_attr:012o} != 0x{inf_attr:012o}"
+            )
+
+    output_file.unlink()
+
+
+def test_retag_does_not_leak_zip64_into_local_headers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A ZIP64 extra field (id 0x0001) stores the central-directory-only
+    # header offset; it is invalid in a local file header. Retagging copied
+    # each source ZipInfo verbatim, so ZIP64 entries produced corrupt local
+    # headers that strict parsers reject (#692). Force ZIP64 on small files.
+    monkeypatch.setattr(zipfile, "ZIP64_LIMIT", 512)
+
+    wheelpath = tmp_path / "test-1.0-py3-none-any.whl"
+    with WheelFile(wheelpath, "w", compression=ZIP_STORED) as wheel_file:
+        wheel_file.writestr("test/padding1", b"x" * 400)
+        wheel_file.writestr("test/padding2", b"x" * 400)
+        wheel_file.writestr("test/__init__.py", b"")
+        wheel_file.writestr(
+            "test-1.0.dist-info/WHEEL",
+            "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+        )
+        wheel_file.writestr(
+            "test-1.0.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: test\nVersion: 1.0\n",
+        )
+
+    # Sanity check: the source really has ZIP64 entries.
+    with ZipFile(wheelpath) as source:
+        assert any(
+            item.extra[:2] == b"\x01\x00" for item in source.infolist()
+        )
+
+    newname = tags(str(wheelpath), platform_tags="linux_x86_64")
+    output_file = wheelpath.parent / newname
+
+    with ZipFile(output_file) as retagged, output_file.open("rb") as raw:
+        for item in retagged.infolist():
+            raw.seek(item.header_offset + 26)
+            name_size, extra_size = struct.unpack("<HH", raw.read(4))
+            raw.seek(name_size, 1)
+            extra = raw.read(extra_size)
+            assert extra[:2] != b"\x01\x00", (
+                f"{item.filename} local header carries a ZIP64 extra field"
             )
 
     output_file.unlink()


### PR DESCRIPTION
Fixes #692.

`wheel tags` rewrites a wheel by passing each source `ZipInfo` straight to `writestr`. For entries stored past `ZIP64_LIMIT`, that `ZipInfo` carries a ZIP64 extended-information extra field (id `0x0001`) holding the central-directory header offset. That field is only valid in the central directory — copied into a local file header it produces an archive that strict parsers reject (this surfaced via uv's stronger zip validation; see the pytorch/uv upstream issues linked in #692).

The fix strips the ZIP64 extra field from each entry before rewriting, so `zipfile` regenerates a correct one for the new archive when needed. Other extra fields are preserved.

### Testing
Added `test_retag_does_not_leak_zip64_into_local_headers`, which forces ZIP64 on small files via `ZIP64_LIMIT`, retags, and asserts no local header carries a `0x0001` extra field. It fails on `main` and passes with the fix; the full suite stays green, and the retagged archive passes `ZipFile.testzip()`.

Two commits kept separate so the failing test lands first, then the fix.

<sub>disclosure: fix + test written with AI assistance; i reproduced the bug, verified fails-before/passes-after locally, and reviewed every line.</sub>
