### PR TITLE
fix: correct singular/plural in macOS platform-tag warning

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+**UNRELEASED**
+
+- Fixed the macOS platform-tag warning always using the plural "these files"
+  wording, even when only a single library required a higher deployment target
+  (`#697 <https://github.com/pypa/wheel/pull/697>`_)
+
 **0.48.0 (2026-08-12)**
 
 - Added a ``--local-version`` option to ``wheel pack`` to add, replace, or remove a

--- a/src/wheel/macosx_libfile.py
+++ b/src/wheel/macosx_libfile.py
@@ -460,7 +460,7 @@ def calculate_macosx_platform_tag(archive_root: StrPath, platform_tag: str) -> s
             files_form = "this file"
         else:
             files_form = "these files"
-        problematic_files = "\n".join(problematic_files)
+        problematic_files_text = "\n".join(problematic_files)
         error_message = (
             "[WARNING] This wheel needs a higher macOS version than {}  "
             "To silence this warning, set MACOSX_DEPLOYMENT_TARGET to at least "
@@ -468,7 +468,7 @@ def calculate_macosx_platform_tag(archive_root: StrPath, platform_tag: str) -> s
             + " or recreate "
             + files_form
             + " with lower "
-            "MACOSX_DEPLOYMENT_TARGET:  \n" + problematic_files
+            "MACOSX_DEPLOYMENT_TARGET:  \n" + problematic_files_text
         )
 
         if "MACOSX_DEPLOYMENT_TARGET" in os.environ:

--- a/src/wheel/macosx_libfile.py
+++ b/src/wheel/macosx_libfile.py
@@ -456,11 +456,11 @@ def calculate_macosx_platform_tag(archive_root: StrPath, platform_tag: str) -> s
     fin_base_version = "_".join([str(x) for x in base_version])
     if start_version < base_version:
         problematic_files = [k for k, v in versions_dict.items() if v > start_version]
-        problematic_files = "\n".join(problematic_files)
         if len(problematic_files) == 1:
             files_form = "this file"
         else:
             files_form = "these files"
+        problematic_files = "\n".join(problematic_files)
         error_message = (
             "[WARNING] This wheel needs a higher macOS version than {}  "
             "To silence this warning, set MACOSX_DEPLOYMENT_TARGET to at least "

--- a/tests/test_macosx_libfile.py
+++ b/tests/test_macosx_libfile.py
@@ -24,6 +24,7 @@ def test_calculate_macosx_platform_tag_files_form(
 ) -> None:
     for index in range(dylib_count):
         tmp_path.joinpath(f"lib{index}.dylib").touch()
+
     monkeypatch.setattr(
         macosx_libfile,
         "extract_macosx_min_system_version",

--- a/tests/test_macosx_libfile.py
+++ b/tests/test_macosx_libfile.py
@@ -23,8 +23,7 @@ def test_calculate_macosx_platform_tag_files_form(
     expected_form: str,
 ) -> None:
     for index in range(dylib_count):
-        tmp_path.joinpath(f"lib{index}.dylib").write_bytes(b"")
-
+        tmp_path.joinpath(f"lib{index}.dylib").touch()
     monkeypatch.setattr(
         macosx_libfile,
         "extract_macosx_min_system_version",

--- a/tests/test_macosx_libfile.py
+++ b/tests/test_macosx_libfile.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wheel import macosx_libfile
+from wheel.macosx_libfile import calculate_macosx_platform_tag
+
+
+@pytest.mark.parametrize(
+    ("dylib_count", "expected_form"),
+    [
+        pytest.param(1, "this file", id="single"),
+        pytest.param(2, "these files", id="multiple"),
+    ],
+)
+def test_calculate_macosx_platform_tag_files_form(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    dylib_count: int,
+    expected_form: str,
+) -> None:
+    for index in range(dylib_count):
+        tmp_path.joinpath(f"lib{index}.dylib").write_bytes(b"")
+
+    monkeypatch.setattr(
+        macosx_libfile,
+        "extract_macosx_min_system_version",
+        lambda path: (11, 0, 0),
+    )
+
+    tag = calculate_macosx_platform_tag(str(tmp_path), "macosx-10.9-x86_64")
+
+    assert tag == "macosx_11_0_x86_64"
+    warning = capsys.readouterr().err
+    assert expected_form in warning


### PR DESCRIPTION
## Problem

In `calculate_macosx_platform_tag()` the list of libraries that need a higher
deployment target is built and then immediately rebound to a joined string:

```python
problematic_files = [k for k, v in versions_dict.items() if v > start_version]
problematic_files = "\n".join(problematic_files)
if len(problematic_files) == 1:
    files_form = "this file"
else:
    files_form = "these files"
```

By the time `len(problematic_files) == 1` runs, `problematic_files` is a string,
so `len()` counts *characters*, not files. A single-file path is many characters
long, so the count is never `1` — the `"this file"` branch is effectively dead
and the warning always reads `"these files"`, even when exactly one library is
at fault.

## Fix

Compute `files_form` from the list length *before* joining.

## Test

New `tests/test_macosx_libfile.py` (the module had no test file). It monkeypatches
`extract_macosx_min_system_version` so no real Mach-O binaries are needed, and is
parametrized over one vs. two `.dylib` files, asserting the warning says
`"this file"` vs. `"these files"` respectively. Fails before the fix (single
case), passes after.

`docs/news.rst` updated under a new `**UNRELEASED**` section.

<sub>for the record: fix found + patched with AI assistance; reviewed and tested by me.</sub>
